### PR TITLE
Add password protection for the slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,63 @@ It has the same configuration as the previous slot:
 | timeout        | Time to wait for a confirmation on the clients that the message was received. |
 | dereg_tries    | Number of messages that are tried on a client until is de-registered. |
 
+## Auth
+
+Ghoti allows to have an authentication mechanism to allow different actors to interact only with specific slots. This means that you can configure who access which slots and who is able to read or write on it.
+
+First, you need to define your client services or users on the configuration:
+
+```yaml
+users:
+  my_service: "my_password"
+  other_service: "another_password"
+  upstream: "123456"
+```
+
+The clients can now login using the `u` and `p` commands:
+
+```
+send   > umy_service
+receive< vmy_service
+send   > pmy_password
+receive< vmy_service
+```
+
+The server will respond with the `v` value returning the username of the logged in user or `e` if there is an error. It is recommended using this feature only through a secure connection, on a very secure network or through TTL because the passwords will not be encoded.
+
+Now, all the interactions with the server will be throught the autenticated user.
+
+After defining the users, we can update the slots with the specific permissions:
+
+```yaml
+slot_001:
+  kind: simple_memory
+  users:
+    my_service: "r"
+    other_service: "w"
+    upstream: "a"
+
+slot_002:
+  kind: simple_memory
+  users:
+    my_service: "a"
+
+slot_003:
+  kind: simple_memory
+```
+
+There are three possible configurations for the access:
+- r: read only
+- w: write only
+- a: all access
+
+With this configuration, the client `my_service` can ready both slots 001 and 002 but can only write on the slot 002.
+
+**IMPORTANT**:
+When a slot has no defined list of users, then it will have anonymous access by default. This means that the slot can be accessed by anyone with or without logging in.
+
+For example, the slot 003 in the configuration can be accessed by anyone, even if is not logged in.
+
 ## Cluster configuration 
 
 Usually Ghoti clusters have no more than 3 instances. The clients will connect simultaneously to all the instances, this way they can recover instantly if there is an issue.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,7 +1,29 @@
 package auth
 
-import ()
+import (
+	"fmt"
+	"regexp"
+)
 
 type User struct {
-	Name string
+	Name     string
+	Password string
+}
+
+func GetUser(name string, password string) (User, error) {
+	if len(name) == 0 {
+		return User{}, fmt.Errorf("there is no user name defined")
+	}
+
+	if len(password) == 0 {
+		return User{}, fmt.Errorf("there is no password defined")
+	}
+
+	match, _ := regexp.MatchString("^[a-zA-Z]+[\\w]*$", name)
+
+	if !match {
+		return User{}, fmt.Errorf("Username can only contain letters, numbers or underscore")
+	}
+
+	return User{Name: name, Password: password}, nil
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,8 +1,10 @@
 package auth
 
 import (
+	"encoding/base64"
 	"fmt"
 	"regexp"
+	"strings"
 )
 
 type User struct {
@@ -26,4 +28,23 @@ func GetUser(name string, password string) (User, error) {
 	}
 
 	return User{Name: name, Password: password}, nil
+}
+
+func Login(value string) (User, error) {
+	data, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		return User{}, fmt.Errorf("User cannot be base64 decoded")
+	}
+
+	userArray := strings.SplitN(string(data), ":", 2)
+	if len(userArray) != 2 {
+		return User{}, fmt.Errorf("Missing username or password")
+	}
+
+	user, err := GetUser(userArray[0], userArray[1])
+	if err != nil {
+		return User{}, err
+	}
+
+	return user, nil
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,0 +1,7 @@
+package auth
+
+import ()
+
+type User struct {
+	Name string
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,10 +1,8 @@
 package auth
 
 import (
-	"encoding/base64"
 	"fmt"
 	"regexp"
-	"strings"
 )
 
 type User struct {
@@ -12,39 +10,30 @@ type User struct {
 	Password string
 }
 
-func GetUser(name string, password string) (User, error) {
+func ValidateUsername(name string) error {
 	if len(name) == 0 {
-		return User{}, fmt.Errorf("there is no user name defined")
-	}
-
-	if len(password) == 0 {
-		return User{}, fmt.Errorf("there is no password defined")
+		return fmt.Errorf("there is no user name defined")
 	}
 
 	match, _ := regexp.MatchString("^[a-zA-Z]+[\\w]*$", name)
 
 	if !match {
-		return User{}, fmt.Errorf("Username can only contain letters, numbers or underscore")
+		return fmt.Errorf("Username can only contain letters, numbers or underscore")
 	}
 
-	return User{Name: name, Password: password}, nil
+	return nil
 }
 
-func Login(value string) (User, error) {
-	data, err := base64.StdEncoding.DecodeString(value)
-	if err != nil {
-		return User{}, fmt.Errorf("User cannot be base64 decoded")
+func GetUser(name string, password string) (User, error) {
+	if len(password) == 0 {
+		return User{}, fmt.Errorf("there is no password defined")
 	}
 
-	userArray := strings.SplitN(string(data), ":", 2)
-	if len(userArray) != 2 {
-		return User{}, fmt.Errorf("Missing username or password")
-	}
+	err := ValidateUsername(name)
 
-	user, err := GetUser(userArray[0], userArray[1])
 	if err != nil {
 		return User{}, err
 	}
 
-	return user, nil
+	return User{Name: name, Password: password}, nil
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,65 @@
+package auth
+
+import (
+	"testing"
+)
+
+func TestCreateUser(t *testing.T) {
+	user, e := GetUser("name", "pass")
+
+	if e != nil {
+		t.Fatalf("user creation returned an error: %s", e)
+	}
+
+	if user.Name != "name" {
+		t.Fatalf("user name must be name")
+	}
+
+	if user.Password != "pass" {
+		t.Fatalf("user password must be pass")
+	}
+}
+
+func TestEmptyPassword(t *testing.T) {
+	_, e := GetUser("name", "")
+
+	if e == nil {
+		t.Fatalf("user creation did not return an error")
+	}
+}
+
+func TestEmptyUser(t *testing.T) {
+	_, e := GetUser("", "pass")
+
+	if e == nil {
+		t.Fatalf("user creation did not return an error")
+	}
+}
+
+func TestUsernameSpecialChars(t *testing.T) {
+	_, e := GetUser("?user", "pass")
+
+	if e == nil {
+		t.Fatalf("user creation did not return an error")
+	}
+}
+
+func TestUsernameStartsWithNumber(t *testing.T) {
+	_, e := GetUser("2name3", "pass")
+
+	if e == nil {
+		t.Fatalf("user creation did not return an error")
+	}
+}
+
+func TestUsernameWithLettersAndNumbers(t *testing.T) {
+	user, e := GetUser("name3_2abc", "pass")
+
+	if e != nil {
+		t.Fatalf("user creation returned an error: %s", e)
+	}
+
+	if user.Name != "name3_2abc" {
+		t.Fatalf("user name must be name3_2abc")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,20 +36,30 @@ func LoadConfig() (*Config, error) {
 		return nil, fmt.Errorf("failed to unmarshal server config: %w", err)
 	}
 
-	config.LoadUsers()
 	config.ConfigureSlots()
+
+	e := config.LoadUsers()
+	if e != nil {
+		return nil, e
+	}
+
 	return config, nil
 }
 
-func (c *Config) LoadUsers() {
+func (c *Config) LoadUsers() error {
 	if viper.IsSet("users") {
 		usersMap := viper.GetStringMap("users")
 		for key, value := range usersMap {
 			pass := fmt.Sprintf("%v", value)
-			u, _ := auth.GetUser(key, pass)
+			u, e := auth.GetUser(key, pass)
+			if e != nil {
+				return e
+			}
+
 			c.Users[key] = u
 		}
 	}
+	return nil
 }
 
 func (c *Config) ConfigureSlots() {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -66,3 +66,50 @@ func TestConfigureUnknownType(t *testing.T) {
 		t.Fatalf("slot zero should not be configured")
 	}
 }
+
+func TestUserSetup(t *testing.T) {
+	viper.Reset()
+
+	viper.Set("users.pepe", "SomePassword")
+
+	config := DefaultConfig()
+	config.LoadUsers()
+
+	if config.Users["pepe"].Name != "pepe" {
+		t.Fatalf("user name must be pepe")
+	}
+
+	if config.Users["pepe"].Password != "SomePassword" {
+		t.Fatalf("User pepe password must be SomePassword")
+	}
+}
+
+func TestMultipleUsersSetup(t *testing.T) {
+	viper.Reset()
+
+	viper.Set("users.pepe", "SomePassword")
+	viper.Set("users.bob", "OtherPassword")
+
+	config := DefaultConfig()
+	config.LoadUsers()
+
+	if len(config.Users) != 2 {
+		t.Fatal("number of users created is wrong")
+	}
+
+	if config.Users["pepe"].Name != "pepe" {
+		t.Fatalf("user name must be pepe")
+	}
+
+	if config.Users["bob"].Name != "bob" {
+		t.Fatalf("user name must be bob")
+	}
+
+	if config.Users["pepe"].Password != "SomePassword" {
+		t.Fatalf("User pepe password must be SomePassword")
+	}
+
+	if config.Users["bob"].Password != "OtherPassword" {
+		t.Fatalf("User bob password must be OtherPassword")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -84,6 +84,19 @@ func TestUserSetup(t *testing.T) {
 	}
 }
 
+func TestEmptyPassword(t *testing.T) {
+	viper.Reset()
+
+	viper.Set("users.pepe", "")
+
+	config := DefaultConfig()
+	e := config.LoadUsers()
+
+	if e == nil {
+		t.Fatalf("User creation must fail with no password")
+	}
+}
+
 func TestMultipleUsersSetup(t *testing.T) {
 	viper.Reset()
 

--- a/internal/server/connection.go
+++ b/internal/server/connection.go
@@ -1,0 +1,12 @@
+package server
+
+import (
+	"net"
+
+	"github.com/dankomiocevic/ghoti/internal/auth"
+)
+
+type Connection struct {
+	NetworkConn net.Conn
+	LoggedUser  auth.User
+}

--- a/internal/server/connection.go
+++ b/internal/server/connection.go
@@ -9,4 +9,6 @@ import (
 type Connection struct {
 	NetworkConn net.Conn
 	LoggedUser  auth.User
+	IsLogged    bool
+	Username    string
 }

--- a/internal/server/message.go
+++ b/internal/server/message.go
@@ -12,6 +12,12 @@ type Message struct {
 	Value   string
 }
 
+var SupportedCommands = map[string]bool{
+	"r": true,
+	"w": true,
+	"l": true,
+}
+
 func ParseMessage(size int, buf []byte) (*Message, error) {
 	if buf[size-1] != '\n' {
 		return nil, errors.New("Message is malformed")
@@ -28,8 +34,12 @@ func ParseMessage(size int, buf []byte) (*Message, error) {
 
 	command := input[:1]
 
-	if command != "r" && command != "w" {
+	if SupportedCommands[command] != true {
 		return nil, errors.New("Command not supported")
+	}
+
+	if command == "l" {
+		return &Message{Command: []byte(command)[0], Slot: 0, Value: input[1:]}, nil
 	}
 
 	slot, err := strconv.Atoi(input[1:4])

--- a/internal/server/message.go
+++ b/internal/server/message.go
@@ -15,7 +15,8 @@ type Message struct {
 var SupportedCommands = map[string]bool{
 	"r": true,
 	"w": true,
-	"l": true,
+	"u": true,
+	"p": true,
 }
 
 func ParseMessage(size int, buf []byte) (*Message, error) {
@@ -38,7 +39,7 @@ func ParseMessage(size int, buf []byte) (*Message, error) {
 		return nil, errors.New("Command not supported")
 	}
 
-	if command == "l" {
+	if command == "u" || command == "p" {
 		return &Message{Command: []byte(command)[0], Slot: 0, Value: input[1:]}, nil
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -29,6 +29,8 @@ func generateConfig() *config.Config {
 	slot_three, _ := slots.GetSlot(viper.Sub("slot_001"))
 	c.Slots[3] = slot_three
 
+	viper.Set("users.pepe", "passw0rd")
+
 	return c
 }
 
@@ -214,6 +216,21 @@ func TestReadTimeout(t *testing.T) {
 	response := sendData(t, conn, "r003\n")
 
 	if response != "v003HelloTimeout\n" {
+		t.Fatalf("unexpected server response: %s", response)
+	}
+}
+
+// Tests for login
+
+func TestLogin(t *testing.T) {
+	s, conn := runServer(t)
+	defer s.Stop()
+	defer conn.Close()
+
+	// Login with "pepe:passw0rd"
+	response := sendData(t, conn, "lcGVwZTpwYXNzdzByZA==\n")
+
+	if response != "vOK\n" {
 		t.Fatalf("unexpected server response: %s", response)
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -227,10 +227,50 @@ func TestLogin(t *testing.T) {
 	defer s.Stop()
 	defer conn.Close()
 
-	// Login with "pepe:passw0rd"
-	response := sendData(t, conn, "lcGVwZTpwYXNzdzByZA==\n")
+	// Login as pepe/passw0rd
+	sendData(t, conn, "upepe\n")
+	response := sendData(t, conn, "ppassw0rd\n")
 
-	if response != "vOK\n" {
+	if response != "vpepe\n" {
 		t.Fatalf("unexpected server response: %s", response)
+	}
+}
+
+func TestUser(t *testing.T) {
+	s, conn := runServer(t)
+	defer s.Stop()
+	defer conn.Close()
+
+	// Login as pepe/passw0rd
+	response := sendData(t, conn, "upepe\n")
+
+	if response != "vpepe\n" {
+		t.Fatalf("Server did not return the username: %s", response)
+	}
+}
+
+func TestInvalidUsername(t *testing.T) {
+	s, conn := runServer(t)
+	defer s.Stop()
+	defer conn.Close()
+
+	// Login as pepe/passw0rd
+	response := sendData(t, conn, "upepe!\n")
+
+	if response != "e\n" {
+		t.Fatalf("Server did not return error")
+	}
+}
+
+func TestEmptyPassword(t *testing.T) {
+	s, conn := runServer(t)
+	defer s.Stop()
+	defer conn.Close()
+
+	// Login as pepe/passw0rd
+	response := sendData(t, conn, "p\n")
+
+	if response != "e\n" {
+		t.Fatalf("Server did not return error")
 	}
 }

--- a/internal/slots/slots.go
+++ b/internal/slots/slots.go
@@ -2,25 +2,46 @@ package slots
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"sync"
 	"time"
 
+	"github.com/dankomiocevic/ghoti/internal/auth"
 	"github.com/spf13/viper"
 )
 
 type Slot interface {
 	Read() string
 	Write(string, net.Conn) (string, error)
+	CanRead(*auth.User) bool
+	CanWrite(*auth.User) bool
 }
 
 type memorySlot struct {
+	users map[string]string
 	value string
 	mu    sync.Mutex
 }
 
 func (m *memorySlot) Read() string {
 	return m.value
+}
+
+func (m *memorySlot) CanRead(u *auth.User) bool {
+	if len(m.users) == 0 {
+		return true
+	}
+
+	return m.users[u.Name] == "r" || m.users[u.Name] == "a"
+}
+
+func (m *memorySlot) CanWrite(u *auth.User) bool {
+	if len(m.users) == 0 {
+		return true
+	}
+
+	return m.users[u.Name] == "w" || m.users[u.Name] == "a"
 }
 
 func (m *memorySlot) Write(data string, from net.Conn) (string, error) {
@@ -32,6 +53,7 @@ func (m *memorySlot) Write(data string, from net.Conn) (string, error) {
 }
 
 type timeoutSlot struct {
+	users   map[string]string
 	value   string
 	owner   net.Conn
 	timeout time.Duration
@@ -66,17 +88,41 @@ func (m *timeoutSlot) Write(data string, from net.Conn) (string, error) {
 	return "", errors.New("Permission denied to write slot")
 }
 
+func (m *timeoutSlot) CanRead(u *auth.User) bool {
+	if len(m.users) == 0 {
+		return true
+	}
+
+	return m.users[u.Name] == "r" || m.users[u.Name] == "a"
+}
+
+func (m *timeoutSlot) CanWrite(u *auth.User) bool {
+	if len(m.users) == 0 {
+		return true
+	}
+
+	return m.users[u.Name] == "w" || m.users[u.Name] == "a"
+}
+
 func GetSlot(v *viper.Viper) (Slot, error) {
 	kind := v.GetString("kind")
+	usersConfig := v.GetStringMap("users")
+
+	users := make(map[string]string)
+	if usersConfig != nil {
+		for key, value := range usersConfig {
+			users[key] = fmt.Sprintf("%v", value)
+		}
+	}
 
 	if kind == "simple_memory" {
-		return &memorySlot{value: ""}, nil
+		return &memorySlot{value: "", users: users}, nil
 	}
 
 	if kind == "timeout_memory" {
 		// TODO: validate this data
 		timeoutConfig := v.GetInt("timeout")
-		return &timeoutSlot{value: "", timeout: time.Duration(timeoutConfig) * time.Second, ttl: time.Time{}}, nil
+		return &timeoutSlot{value: "", timeout: time.Duration(timeoutConfig) * time.Second, ttl: time.Time{}, users: users}, nil
 	}
 
 	return nil, errors.New("Invalid kind of slot")


### PR DESCRIPTION
# Description

With this PR, Ghoti can be configured with Users (user/password) in order to protect slots individually for reading and writing.

The configuration file can have a section users, with the username and password:

```
users:
  pepe: password
  sam: otherPassword
```

And then you can configure the slots using these users:

```
slot000:
  kind: simple_memory
  users:
    pepe: r
    sam: w
```

There are three configurations:
- r for read only
- w for write only
- a for all access

The configurations are per slot. In order to login two commands need to be sent, the `u` command to define the username and then the `p` command to define the password.

```
> upepe
> vpepe
> ppassword
> vpepe
```
 
With a response having the `v` value response type followed by the username, it is confirmed that the user is logged in. In order to use this feature I recommend to use TLS to encrypt the communication as the password will be travelling without any encoding.

# Testing
Added coverage for the new feature.