### PR TITLE
Close connection when failure

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,11 +22,6 @@ func NewRootCommand() *cobra.Command {
 		viper.AddConfigPath(path)
 	}
 
-	err := viper.ReadInConfig()
-	if err != nil {
-		panic(err)
-	}
-
 	return &cobra.Command{
 		Use:   "ghoti",
 		Short: "A simple server to do simple things, but fast!",

--- a/cmd/run/config.yaml
+++ b/cmd/run/config.yaml
@@ -1,0 +1,14 @@
+# Example config file for Ghoti
+
+slot_000:
+  kind: simple_memory
+
+slot_001:
+  kind: simple_memory
+
+slot_002:
+  kind: simple_memory
+
+slot_003:
+  kind: timeout_memory
+  timeout: 60

--- a/cmd/run/integration_test.go
+++ b/cmd/run/integration_test.go
@@ -1,0 +1,39 @@
+package run
+
+import (
+	"bufio"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/dankomiocevic/ghoti/cmd"
+)
+
+func TestSingleNode(t *testing.T) {
+	rootCmd := cmd.NewRootCommand()
+	cmd := NewRunCommand()
+	rootCmd.AddCommand(cmd)
+
+	rootCmd.SetArgs([]string{"run", "--addr", "localhost:9876"})
+
+	go func() {
+		rootCmd.Execute()
+	}()
+
+	time.Sleep(time.Duration(100) * time.Millisecond)
+	// connect to the TCP Server
+	conn, err := net.Dial("tcp", ":9876")
+	if err != nil {
+		t.Fatalf("couldn't connect to the server: %v", err)
+	}
+
+	if _, err := conn.Write([]byte("r000\n")); err != nil {
+		t.Fatalf("couldn't send request: %v", err)
+	}
+
+	reader := bufio.NewReader(conn)
+	response, err := reader.ReadBytes(byte('\n'))
+	if string(response[0]) == "e" {
+		t.Fatalf("received error response: %v", string(response))
+	}
+}

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -42,7 +42,7 @@ func run(_ *cobra.Command, _ []string) {
 		panic(err)
 	}
 
-	if len(config.Cluster.Node) < 1 {
+	if len(config.Cluster.Node) > 0 {
 		c, err := cluster.NewCluster(config.Cluster)
 		if err != nil {
 			panic(err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,10 @@ func LoadConfig() (*Config, error) {
 		return nil, fmt.Errorf("failed to unmarshal server config: %w", err)
 	}
 
+	if viper.IsSet("addr") {
+		config.TcpAddr = viper.GetString("addr")
+	}
+
 	config.ConfigureSlots()
 
 	e := config.LoadUsers()

--- a/internal/server/connection.go
+++ b/internal/server/connection.go
@@ -12,3 +12,7 @@ type Connection struct {
 	IsLogged    bool
 	Username    string
 }
+
+func (c *Connection) Close() error {
+	return c.NetworkConn.Close()
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -68,7 +68,7 @@ func (s *Server) Stop() {
 }
 
 func (s *Server) handleUserConnection(conn Connection) {
-	defer conn.NetworkConn.Close()
+	defer conn.Close()
 
 	c := conn.NetworkConn
 	buf := make([]byte, 41)
@@ -91,7 +91,7 @@ func (s *Server) handleUserConnection(conn Connection) {
 			if err != nil {
 				res := errors.Error("WRONG_USER")
 				c.Write([]byte(res.Response()))
-				// TODO: Close connection
+				return
 			} else {
 				conn.LoggedUser = auth.User{}
 				conn.Username = msg.Value
@@ -111,12 +111,12 @@ func (s *Server) handleUserConnection(conn Connection) {
 			if err != nil {
 				res := errors.Error("WRONG_PASS")
 				c.Write([]byte(res.Response()))
-				// TODO: Close connection
+				return
 			} else {
 				if s.usersMap[user.Name].Password != user.Password {
 					res := errors.Error("WRONG_LOGIN")
 					c.Write([]byte(res.Response()))
-					// TODO: Close connection
+					return
 				} else {
 					conn.LoggedUser = user
 					conn.IsLogged = true
@@ -154,7 +154,7 @@ func (s *Server) handleUserConnection(conn Connection) {
 				continue
 			}
 		} else if msg.Command == 'q' {
-			// TODO: Close connection
+			return
 		} else if msg.Command == 'r' {
 			if current_slot.CanRead(&conn.LoggedUser) {
 				value = current_slot.Read()


### PR DESCRIPTION
# Description

When there is a connection error or the client sends a disconnect command, we need to close the connection. This PR implements the closing, this will be used in future commands to release resources if needed.

Also, fixes a problem with the server address configuration on the CLI.