### PR TITLE
Return leader for NOT_LEADER error

### DIFF
--- a/cmd/run/integration_test.go
+++ b/cmd/run/integration_test.go
@@ -20,7 +20,9 @@ func TestSingleNode(t *testing.T) {
 		rootCmd.Execute()
 	}()
 
+	// Let the TCP server be ready
 	time.Sleep(time.Duration(100) * time.Millisecond)
+
 	// connect to the TCP Server
 	conn, err := net.Dial("tcp", ":9876")
 	if err != nil {

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -14,8 +14,10 @@ type Cluster interface {
 	Start() error
 	Join(string, string) error
 	Bootstrap() raft.Future
-	State() raft.RaftState
+	IsLeader() bool
+	GetLeader() string
 	Shutdown() raft.Future
+	state() raft.RaftState
 }
 
 type RaftCluster struct {
@@ -39,6 +41,10 @@ func NewCluster(config ClusterConfig) (Cluster, error) {
 
 func (c *RaftCluster) Shutdown() raft.Future {
 	return c.raft.Shutdown()
+}
+
+func (c *RaftCluster) state() raft.RaftState {
+	return c.raft.State()
 }
 
 func (c *RaftCluster) Start() error {
@@ -75,8 +81,13 @@ func (c *RaftCluster) Start() error {
 	return nil
 }
 
-func (c *RaftCluster) State() raft.RaftState {
-	return c.raft.State()
+func (c *RaftCluster) IsLeader() bool {
+	return c.raft.State() == raft.Leader
+}
+
+func (c *RaftCluster) GetLeader() string {
+	_, id := c.raft.LeaderWithID()
+	return string(id)
 }
 
 func (c *RaftCluster) Bootstrap() raft.Future {

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -25,7 +25,7 @@ func TestClusterSingleNode(t *testing.T) {
 	// Exponential retry until set as leader
 	baseDelay := 100 * time.Millisecond
 	for i := 0; i < 7; i++ {
-		if c.State() == raft.Leader {
+		if c.state() == raft.Leader {
 			return
 		}
 

--- a/internal/cluster/empty_cluster.go
+++ b/internal/cluster/empty_cluster.go
@@ -30,10 +30,18 @@ func (c *EmptyCluster) Bootstrap() raft.Future {
 	return &EmptyFuture{}
 }
 
-func (c *EmptyCluster) State() raft.RaftState {
-	return raft.Leader
+func (c *EmptyCluster) IsLeader() bool {
+	return true
+}
+
+func (c *EmptyCluster) GetLeader() string {
+	return ""
 }
 
 func (c *EmptyCluster) Shutdown() raft.Future {
 	return &EmptyFuture{}
+}
+
+func (c *EmptyCluster) state() raft.RaftState {
+	return raft.Leader
 }

--- a/internal/cluster/integration_test.go
+++ b/internal/cluster/integration_test.go
@@ -36,7 +36,7 @@ func TestClusterMultiNode(t *testing.T) {
 	// Exponential retry until set as leader
 	baseDelay := 100 * time.Millisecond
 	for i := 0; i < 7; i++ {
-		if node_one.State() == raft.Leader {
+		if node_one.state() == raft.Leader {
 			break
 		}
 
@@ -44,8 +44,8 @@ func TestClusterMultiNode(t *testing.T) {
 		delay := time.Duration(secRetry) * baseDelay
 		time.Sleep(delay)
 	}
-	if node_one.State() != raft.Leader {
-		t.Fatalf("Node one not set as leader, state: %s", node_one.State())
+	if node_one.state() != raft.Leader {
+		t.Fatalf("Node one not set as leader, state: %s", node_one.state())
 	}
 
 	err = node_two.Start()
@@ -56,7 +56,7 @@ func TestClusterMultiNode(t *testing.T) {
 	// Exponential retry until node 2 is set as follower
 	baseDelay = 100 * time.Millisecond
 	for i := 0; i < 7; i++ {
-		if node_two.State() == raft.Follower {
+		if node_two.state() == raft.Follower {
 			break
 		}
 
@@ -64,8 +64,8 @@ func TestClusterMultiNode(t *testing.T) {
 		delay := time.Duration(secRetry) * baseDelay
 		time.Sleep(delay)
 	}
-	if node_two.State() != raft.Follower {
-		t.Fatalf("Node two not set as follower, state: %s", node_two.State())
+	if node_two.state() != raft.Follower {
+		t.Fatalf("Node two not set as follower, state: %s", node_two.state())
 	}
 
 	err = node_three.Start()
@@ -76,7 +76,7 @@ func TestClusterMultiNode(t *testing.T) {
 	// Exponential retry until node 3 is set as follower
 	baseDelay = 100 * time.Millisecond
 	for i := 0; i < 7; i++ {
-		if node_three.State() == raft.Follower {
+		if node_three.state() == raft.Follower {
 			break
 		}
 
@@ -84,8 +84,8 @@ func TestClusterMultiNode(t *testing.T) {
 		delay := time.Duration(secRetry) * baseDelay
 		time.Sleep(delay)
 	}
-	if node_three.State() != raft.Follower {
-		t.Fatalf("Node three not set as follower, state: %s", node_three.State())
+	if node_three.state() != raft.Follower {
+		t.Fatalf("Node three not set as follower, state: %s", node_three.state())
 	}
 
 	// Shutting down leader node
@@ -93,7 +93,7 @@ func TestClusterMultiNode(t *testing.T) {
 	// Exponential retry until another node becomes leader
 	baseDelay = 100 * time.Millisecond
 	for i := 0; i < 7; i++ {
-		if node_two.State() == raft.Leader || node_three.State() == raft.Leader {
+		if node_two.state() == raft.Leader || node_three.state() == raft.Leader {
 			break
 		}
 
@@ -101,7 +101,7 @@ func TestClusterMultiNode(t *testing.T) {
 		delay := time.Duration(secRetry) * baseDelay
 		time.Sleep(delay)
 	}
-	if node_two.State() != raft.Leader && node_three.State() != raft.Leader {
-		t.Fatalf("Node two or three not set as leader, state_two: %s, state_three: %s", node_two.State(), node_three.State())
+	if node_two.state() != raft.Leader && node_three.state() != raft.Leader {
+		t.Fatalf("Node two or three not set as leader, state_two: %s, state_three: %s", node_two.state(), node_three.state())
 	}
 }

--- a/internal/cluster/membership_manager_test.go
+++ b/internal/cluster/membership_manager_test.go
@@ -20,7 +20,7 @@ func (m *MockedCluster) Join(node string, addr string) error {
 	return args.Error(0)
 }
 
-func (m *MockedCluster) State() raft.RaftState {
+func (m *MockedCluster) state() raft.RaftState {
 	args := m.Called()
 	return args.Get(0).(raft.RaftState)
 }
@@ -33,6 +33,16 @@ func (m *MockedCluster) Bootstrap() raft.Future {
 func (m *MockedCluster) Shutdown() raft.Future {
 	args := m.Called()
 	return args.Get(0).(raft.Future)
+}
+
+func (m *MockedCluster) GetLeader() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *MockedCluster) IsLeader() bool {
+	args := m.Called()
+	return args.Bool(0)
 }
 
 func TestJoinServer(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,8 +15,6 @@ import (
 	"github.com/dankomiocevic/ghoti/internal/config"
 	"github.com/dankomiocevic/ghoti/internal/errors"
 	"github.com/dankomiocevic/ghoti/internal/slots"
-
-	"github.com/hashicorp/raft"
 )
 
 type Server struct {
@@ -161,9 +159,9 @@ func (s *Server) handleUserConnection(conn Connection) {
 			)
 		}
 
-		if msg.Command != 'q' && s.cluster.State() != raft.Leader {
+		if msg.Command != 'q' && !s.cluster.IsLeader() {
 			res := errors.Error("NOT_LEADER")
-			c.Write([]byte(res.Response()))
+			c.Write([]byte(res.Response() + s.cluster.GetLeader()))
 			slog.Debug("Request made to node that was not leader",
 				slog.String("id", conn.Id),
 				slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),


### PR DESCRIPTION
# Description

When calling a follower node with a request, the follower node cannot return any data. It will return an error instead, that error must contain the correct leader node that should be contacted:

```
e000node1
```

This PR adds the node to the information returned.