### PR TITLE
Add token bucket slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ This way the applications can use a single server to solve more than one problem
 This is the most basic slot where a value can be stored. The value has a maximum of 36 characters. You can read and write on the value and there are no restrictions.
 This slot has also no configuration.
 
+Example config:
+
+```yaml
+slot_000:
+  type: simple_memory
+```
+
 ### Timeout memory slot
 
 This slot is also a memory slot but the main difference with the Simple memory slot is that it has an owner. Only the client that has last written in this slot can write again.
@@ -90,6 +97,13 @@ The timeout can be configured:
 |timeout     |Timeout value configured in seconds.|
 
 All clients can read from this slot, but only the owner can write. If any other client tries to write it will fail. If there is no owner, the first client that writes becomes the owner.
+
+Example config:
+```yaml
+slot_001:
+  type: timeout_memory
+  timeout: 10
+```
 
 ### Token bucket limiter
 
@@ -118,7 +132,18 @@ The complete configuration options are:
 
 Writes have no effect on this slot. Reads will return the number of tokens (or zero if there are no tokens available).
 
-### Leaky bucket limiter
+
+Example config:
+```yaml
+slot_002:
+  type: token_bucket
+  bucket_size: 100
+  period: second
+  refresh_rate: 50
+  tokens_per_req: 5
+```
+
+### Leaky bucket limiter (TBD)
 
 This limiter works by defining an imaginary bucket that has a leak on it. The idea is that the leak is the rate how those tokens get delivered at a constant rate.
 
@@ -136,7 +161,7 @@ As it can be interpreted from this description, this algorithm is more network i
 
 Writes have no effect on this slot. Reads will return 1 if the token was accepted or zero if not.
 
-### Broadcast signal propagation
+### Broadcast signal propagation (TBD)
 
 Anything sent to this slot is propagated as a message to all the other clients. Any client connected to Ghoti at this point will receive the event at least once.
 This means that the message could be received more than once.
@@ -155,7 +180,7 @@ This slot will only acknowledge the command when all the messages are sent, so t
 
 Writes will propagate the written value to all other clients. Reads will read the last written value.
 
-### Multicast signal propagation
+### Multicast signal propagation (TBD)
 
 Similar to the Broadcast slot but this slot allows to send a message to a specific group of clients. This type of multicast **requires 2 consecutive slots:**
 - Register/Deregister: This slot allows a client to register or deregister from the multicast. If the client is registered, it will receive the events. To register a client can write a value on this slot, to deregister it can write zero. If a client reads this slot, then a non-zero value means the client is already registered and a zero value means is not.
@@ -167,7 +192,7 @@ Similar to the Broadcast slot but this slot allows to send a message to a specif
 | dereg_tries    | Number of messages that are tried on a client until is de-registered. |
 
 
-### Random signal propagation
+### Random signal propagation (TBD)
 
 This signal propagation slot works like the Multicast signal propagation explained before but with a major diference, the message is not sent to all registered clients, but only one. It uses a pseudo-random generator to distribute the messages among the clients.
 
@@ -183,7 +208,7 @@ It has the same configuration as the previous slot:
 | dereg_tries    | Number of messages that are tried on a client until is de-registered. |
 
 
-### Ticker (watchdog)
+### Ticker (watchdog) (TBD)
 
 This is a classic slot used in embedded circuits and microcontrollers, the slot contains an integer value, the way this works is that the slot will tick once a second making its value go down by one until it reaches zero.
 If any client writes to this slot and sets a value (integer value), it will start decrementing that value once a second until it reaches zero again.
@@ -193,7 +218,7 @@ In other words, if a client writes `600` on this slot, then waits 9 minutes and 
 There is no configuration needed for this slot.
 
 
-### Atomic counter slot
+### Atomic counter slot (TBD)
 
 This slot contains an integer number and allows to increment or decrement its value. Only one process can increment or decrement the value at a time.
 
@@ -258,7 +283,7 @@ When a slot has no defined list of users, then it will have anonymous access by 
 
 For example, the slot 003 in the configuration can be accessed by anyone, even if is not logged in.
 
-## Cluster configuration 
+## Cluster configuration (Experimental)
 
 Ghoti clusters are created to increment availability, they are not supposed to propagate information to other nodes in order to increase data persistence. When a cluster node fails, another node will take its place but it will start on a clean state without keeping track of the information stored before.
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -54,6 +54,21 @@ func TestConfigureTimeoutSlot(t *testing.T) {
 	}
 }
 
+func TestConfigureTokenBucketSlot(t *testing.T) {
+	resetViper()
+
+	viper.Set("slot_000.kind", "token_bucket")
+	viper.Set("slot_000.bucket_size", 50)
+	viper.Set("slot_000.period", "second")
+
+	config := DefaultConfig()
+	config.ConfigureSlots()
+
+	if config.Slots[0] == nil {
+		t.Fatalf("slot zero not configured")
+	}
+}
+
 func TestNotConfigureSlot(t *testing.T) {
 	resetViper()
 

--- a/internal/slots/timeout.go
+++ b/internal/slots/timeout.go
@@ -2,6 +2,7 @@ package slots
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"sync"
 	"time"
@@ -16,6 +17,14 @@ type timeoutSlot struct {
 	timeout time.Duration
 	ttl     time.Time
 	mu      sync.Mutex
+}
+
+func newTimeoutSlot(timeout int, users map[string]string) (*timeoutSlot, error) {
+	if timeout < 1 {
+		return nil, fmt.Errorf("Timeout value in timeout_memory slot must be bigger than zero")
+	}
+
+	return &timeoutSlot{value: "", timeout: time.Duration(timeout) * time.Second, ttl: time.Time{}, users: users}, nil
 }
 
 func (m *timeoutSlot) Read() string {

--- a/internal/slots/timeout_test.go
+++ b/internal/slots/timeout_test.go
@@ -1,0 +1,145 @@
+package slots
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/dankomiocevic/ghoti/internal/auth"
+	"github.com/spf13/viper"
+)
+
+func loadTimeoutSlot(t *testing.T) Slot {
+	v := viper.New()
+
+	v.Set("kind", "timeout_memory")
+	v.Set("timeout", 1)
+	v.Set("users.read", "r")
+	v.Set("users.write", "w")
+	v.Set("users.allu", "a")
+
+	slot, err := GetSlot(v)
+	if err != nil {
+		t.Fatalf("Slot must not return error: %s", err)
+	}
+	return slot
+}
+
+func TestTimeoutMemory(t *testing.T) {
+	slot := loadTimeoutSlot(t)
+
+	timeoutSlot := slot.(*timeoutSlot)
+	if timeoutSlot.timeout != 1*time.Second {
+		t.Fatalf("timeout must be 10: %s", timeoutSlot.timeout)
+	}
+}
+
+func TestTimeoutRead(t *testing.T) {
+	read_user, _ := auth.GetUser("read", "pass")
+	write_user, _ := auth.GetUser("write", "pass")
+	all_user, _ := auth.GetUser("allu", "pass")
+
+	slot := loadTimeoutSlot(t)
+
+	if !slot.CanRead(&read_user) {
+		t.Fatalf("we should be able to read with the read user")
+	}
+
+	if slot.CanRead(&write_user) {
+		t.Fatalf("we should not be able to read with the write user")
+	}
+
+	if !slot.CanRead(&all_user) {
+		t.Fatalf("we should be able to read with the read/write user")
+	}
+}
+
+func TestTimeoutWrite(t *testing.T) {
+	read_user, _ := auth.GetUser("read", "pass")
+	write_user, _ := auth.GetUser("write", "pass")
+	all_user, _ := auth.GetUser("allu", "pass")
+
+	slot := loadTimeoutSlot(t)
+
+	if slot.CanWrite(&read_user) {
+		t.Fatalf("we should not be able to write with the read user")
+	}
+
+	if !slot.CanWrite(&write_user) {
+		t.Fatalf("we should be able to write with the write user")
+	}
+
+	if !slot.CanWrite(&all_user) {
+		t.Fatalf("we should be able to write with the read/write user")
+	}
+}
+
+func TestTimeoutMemoryMissingConfig(t *testing.T) {
+	v := viper.New()
+
+	v.Set("kind", "timeout_memory")
+
+	_, err := GetSlot(v)
+	if err == nil {
+		t.Fatalf("Slot must return error")
+	}
+}
+
+func TestMultipleWrites(t *testing.T) {
+	_, client_one := net.Pipe()
+	_, client_two := net.Pipe()
+	slot := loadTimeoutSlot(t)
+
+	resp, err := slot.Write("Hello!", client_one)
+	if err != nil {
+		t.Fatalf("error writing slot: %s", err)
+	}
+
+	if resp != "Hello!" {
+		t.Fatalf("wrong value stored in slot: %s", resp)
+	}
+
+	resp = slot.Read()
+	if resp != "Hello!" {
+		t.Fatalf("wrong value stored in slot: %s", resp)
+	}
+
+	_, err = slot.Write("Hello!", client_two)
+	if err == nil {
+		t.Fatalf("Writing before timeout should fail")
+	}
+
+	resp, err = slot.Write("Hello Again!", client_one)
+	if err != nil {
+		t.Fatalf("error writing slot: %s", err)
+	}
+
+	if resp != "Hello Again!" {
+		t.Fatalf("wrong value stored in slot: %s", resp)
+	}
+
+	resp = slot.Read()
+	if resp != "Hello Again!" {
+		t.Fatalf("wrong value stored in slot: %s", resp)
+	}
+
+	time.Sleep(1 * time.Second)
+	resp, err = slot.Write("Hello back!", client_two)
+	if err != nil {
+		t.Fatalf("error writing slot: %s", err)
+	}
+
+	if resp != "Hello back!" {
+		t.Fatalf("wrong value stored in slot: %s", resp)
+	}
+
+	resp = slot.Read()
+	if resp != "Hello back!" {
+		t.Fatalf("wrong value stored in slot: %s", resp)
+	}
+
+	_, err = slot.Write("Hello!", client_one)
+	if err == nil {
+		t.Fatalf("Writing before timeout should fail")
+	}
+}

--- a/internal/slots/token_bucket.go
+++ b/internal/slots/token_bucket.go
@@ -1,0 +1,94 @@
+package slots
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/dankomiocevic/ghoti/internal/auth"
+)
+
+type tokenBucketSlot struct {
+	users        map[string]string
+	value        int
+	size         int
+	period       int64
+	rate         int
+	window       int64
+	tokensPerReq int
+	mu           sync.Mutex
+}
+
+func newTokenBucketSlot(periodString string, bucketSize, refreshRate, tokensPerReq int, users map[string]string) (*tokenBucketSlot, error) {
+	if bucketSize < 1 {
+		return nil, fmt.Errorf("Bucket size must be bigger than zero")
+	}
+
+	if refreshRate > bucketSize {
+		return nil, fmt.Errorf("Refresh rate cannot be bigger than the bucket size")
+	}
+
+	if refreshRate < 1 {
+		return nil, fmt.Errorf("Refresh rate cannot be zero")
+	}
+
+	if tokensPerReq > bucketSize {
+		return nil, fmt.Errorf("Tokens per request cannot be bigger than the bucket size")
+	}
+
+	if tokensPerReq < 1 {
+		return nil, fmt.Errorf("Tokens per request cannot be zero")
+	}
+
+	var period int64
+	if periodString == "second" {
+		period = 1
+	} else if periodString == "minute" {
+		period = 60
+	} else if periodString == "hour" {
+		period = 3600
+	} else {
+		return nil, fmt.Errorf("Period value is invalid on token_bucket slot: %s", periodString)
+	}
+
+	return &tokenBucketSlot{value: refreshRate, size: bucketSize, period: period, rate: refreshRate, window: currentWindow(period), tokensPerReq: tokensPerReq, users: users}, nil
+}
+
+func currentWindow(period int64) int64 {
+	currentTime := time.Now().Unix()
+	return currentTime / period
+}
+
+func (m *tokenBucketSlot) Read() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	current := currentWindow(m.period)
+	if current != m.window {
+		m.window = current
+		m.value = min(m.size, m.value+m.rate)
+	}
+
+	retVal := min(m.value, m.tokensPerReq)
+
+	m.value = m.value - retVal
+	return strconv.Itoa(retVal)
+}
+
+func (m *tokenBucketSlot) CanRead(u *auth.User) bool {
+	if len(m.users) == 0 {
+		return true
+	}
+
+	return m.users[u.Name] == "r" || m.users[u.Name] == "a"
+}
+
+func (m *tokenBucketSlot) CanWrite(u *auth.User) bool {
+	return false
+}
+
+func (m *tokenBucketSlot) Write(data string, from net.Conn) (string, error) {
+	return "", fmt.Errorf("Token bucket slots cannot be used to write")
+}

--- a/internal/slots/token_bucket_test.go
+++ b/internal/slots/token_bucket_test.go
@@ -1,0 +1,295 @@
+package slots
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dankomiocevic/ghoti/internal/auth"
+	"github.com/spf13/viper"
+)
+
+func loadBucketSlot(t *testing.T) Slot {
+	v := viper.New()
+
+	v.Set("kind", "token_bucket")
+	v.Set("bucket_size", 200)
+	v.Set("refresh_rate", 100)
+	v.Set("period", "second")
+	v.Set("tokens_per_req", 20)
+	v.Set("users.read", "r")
+	v.Set("users.write", "w")
+	v.Set("users.allu", "a")
+
+	slot, err := GetSlot(v)
+	if err != nil {
+		t.Fatalf("Slot must not return error: %s", err)
+	}
+	return slot
+}
+
+func TestTokenBucketSmoke(t *testing.T) {
+	slot := loadBucketSlot(t)
+
+	tokenSlot := slot.(*tokenBucketSlot)
+	if tokenSlot.value != 100 {
+		t.Errorf("Bucket must be started with 100 value: %d", tokenSlot.value)
+	}
+}
+
+func TestTokenBucketRead(t *testing.T) {
+	read_user, _ := auth.GetUser("read", "pass")
+	write_user, _ := auth.GetUser("write", "pass")
+	all_user, _ := auth.GetUser("allu", "pass")
+
+	slot := loadBucketSlot(t)
+
+	if !slot.CanRead(&read_user) {
+		t.Fatalf("we should be able to read with the read user")
+	}
+
+	if slot.CanRead(&write_user) {
+		t.Fatalf("we should not be able to read with the read user")
+	}
+
+	if !slot.CanRead(&all_user) {
+		t.Fatalf("we should be able to read with the read/write user")
+	}
+}
+
+func TestTokenBucketWrite(t *testing.T) {
+	read_user, _ := auth.GetUser("read", "pass")
+	write_user, _ := auth.GetUser("write", "pass")
+	all_user, _ := auth.GetUser("allu", "pass")
+
+	slot := loadBucketSlot(t)
+
+	if slot.CanWrite(&read_user) {
+		t.Fatalf("we should not be able to write with any user")
+	}
+
+	if slot.CanWrite(&write_user) {
+		t.Fatalf("we should not be able to write with any user")
+	}
+
+	if slot.CanWrite(&all_user) {
+		t.Fatalf("we should not be able to write with any user")
+	}
+}
+
+func TestTokenBucketMissingConfig(t *testing.T) {
+	v := viper.New()
+
+	v.Set("kind", "token_bucket")
+
+	_, err := GetSlot(v)
+	if err == nil {
+		t.Fatalf("Slot must return error for missing config")
+	}
+
+	v.Set("bucket_size", 10)
+	_, err = GetSlot(v)
+	if err == nil {
+		t.Fatalf("Slot must return error for missing config")
+	}
+}
+
+func TestTokenBucketWrongSize(t *testing.T) {
+	v := viper.New()
+
+	v.Set("kind", "token_bucket")
+	v.Set("bucket_size", 0)
+
+	_, err := GetSlot(v)
+	if err == nil {
+		t.Fatalf("Slot must return error")
+	}
+
+	v.Set("bucket_size", "A")
+
+	_, err = GetSlot(v)
+	if err == nil {
+		t.Fatalf("Slot must return error")
+	}
+}
+
+func TestTokenBucketWrongTokensPerReq(t *testing.T) {
+	v := viper.New()
+
+	v.Set("kind", "token_bucket")
+	v.Set("period", "second")
+	v.Set("bucket_size", 10)
+	v.Set("refresh_rate", 10)
+	v.Set("tokens_per_req", 12)
+
+	_, err := GetSlot(v)
+	if err == nil {
+		t.Fatalf("Slot must return error")
+	}
+
+	v.Set("tokens_per_req", 12)
+
+	_, err = GetSlot(v)
+	if err == nil {
+		t.Fatalf("Slot must return error")
+	}
+
+	v.Set("tokens_per_req", "A")
+
+	_, err = GetSlot(v)
+	if err == nil {
+		t.Fatalf("Slot must return error")
+	}
+}
+
+func TestTokenBucketWrongRefreshRate(t *testing.T) {
+	v := viper.New()
+
+	v.Set("kind", "token_bucket")
+	v.Set("period", "second")
+	v.Set("bucket_size", 10)
+	v.Set("refresh_rate", 11)
+
+	_, err := GetSlot(v)
+	if err == nil {
+		t.Fatalf("Slot must return error")
+	}
+
+	v.Set("tokens_per_request", "A")
+
+	_, err = GetSlot(v)
+	if err == nil {
+		t.Fatalf("Slot must return error")
+	}
+
+	v.Set("tokens_per_request", 0)
+
+	_, err = GetSlot(v)
+	if err == nil {
+		t.Fatalf("Slot must return error")
+	}
+}
+
+func TestTokenBucketWrongPeriod(t *testing.T) {
+	v := viper.New()
+
+	v.Set("kind", "token_bucket")
+	v.Set("period", "pepe")
+	v.Set("bucket_size", 10)
+
+	_, err := GetSlot(v)
+	if err == nil {
+		t.Fatalf("Slot must return error")
+	}
+
+	v.Set("period", "")
+
+	_, err = GetSlot(v)
+	if err == nil {
+		t.Fatalf("Slot must return error")
+	}
+
+	v.Set("period", 0)
+
+	_, err = GetSlot(v)
+	if err == nil {
+		t.Fatalf("Slot must return error")
+	}
+}
+
+func TestTokenBucketLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test on Short mode")
+	}
+
+	slot := loadBucketSlot(t)
+
+	// Wait until the bucket is full (200 tokens)
+	time.Sleep(1 * time.Second)
+	i := 0
+	for slot.Read() == "20" {
+		i++
+		if i > 11 {
+			t.Fatalf("Slot must return zero after requesting all the tokens")
+		}
+	}
+
+	if i < 10 {
+		t.Fatalf("Slot must return at least 200 correct tokens. Correct: %d", i)
+	}
+
+	if slot.Read() != "0" {
+		t.Fatalf("Slot must return zero after consuming all the tokens")
+	}
+
+	// Wait until the bucket gets a refresh (100 tokens)
+	time.Sleep(1 * time.Second)
+
+	i = 0
+	for slot.Read() == "20" {
+		i++
+		if i > 5 {
+			t.Fatalf("Slot must return zero after requesting all the tokens")
+		}
+	}
+
+	if i < 5 {
+		t.Fatalf("Slot must return at least 100 correct tokens. Correct: %d", i)
+	}
+}
+
+func TestTokenBucketNotMatchingValues(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test on Short mode")
+	}
+
+	v := viper.New()
+
+	v.Set("kind", "token_bucket")
+	v.Set("bucket_size", 111)
+	v.Set("refresh_rate", 65)
+	v.Set("period", "second")
+	v.Set("tokens_per_req", 7)
+
+	slot, err := GetSlot(v)
+	if err != nil {
+		t.Fatalf("Slot must not return error: %s", err)
+	}
+
+	// Wait until the bucket is full (111 tokens)
+	time.Sleep(1 * time.Second)
+	i := 0
+	var value string
+	for i <= 16 {
+		i++
+		value = slot.Read()
+		if value != "7" {
+			break
+		}
+	}
+	if i > 16 {
+		t.Fatalf("Slot must have no more tokens after 16 requests")
+	}
+
+	if value != "6" {
+		t.Fatalf("Slot must return the missing 6 tokens")
+	}
+
+	if slot.Read() != "0" {
+		t.Fatalf("Slot must return zero after consuming all the tokens")
+	}
+
+	// Wait until the bucket gets a refresh (65 tokens)
+	time.Sleep(1 * time.Second)
+
+	i = 0
+	for slot.Read() == "7" {
+		i++
+		if i > 9 {
+			t.Fatalf("Slot must return zero after requesting all the tokens")
+		}
+	}
+
+	if i < 9 {
+		t.Fatalf("Slot must return at least 111 correct tokens. Correct: %d", i)
+	}
+}


### PR DESCRIPTION
# Description

This new slot allows to have a basic token bucket algorithm to allow applications to have a centralized place for a distributed rate limiting.

The token bucket works as:

- A number of tokens is added to the bucket every period defined (second, minute, hour)
- The bucket can hold a maximum of tokens 
- If a token arrives when the bucket is full, it is discarded.

When a request to read the slot arrives, it will receive a pre-defined number of tokens (or the number of available tokens if it is less than that). These tokens will be removed from the bucket.

# Testing
- Unit and integration tests for the slot.
- Increase testing for other slots.