### PR TITLE
Add leaky bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,21 +143,18 @@ slot_002:
   tokens_per_req: 5
 ```
 
-### Leaky bucket limiter (TBD)
+### Leaky bucket limiter
 
 This limiter works by defining an imaginary bucket that has a leak on it. The idea is that the leak is the rate how those tokens get delivered at a constant rate.
 
 The bucket has a limited capacity, then it would remove tokens at a constant rate (defined by config). Every time we do a request, we put a token in the bucket, if there is enough room in the bucket, then the request will be approved, if there is not enough room the request will be denied. When a bucket is full, it will return 0 to all the requests until a token is leaked from it, then it will have room to receive a new token and so on.
 
-This allows applications to have a burst of requests but after some time the bucket will fill up and the requests will start at a constant rate.
+The bucket size allows applications to have a burst of requests but after some time the bucket will fill up and the requests will start at a constant rate. If you don't want to have a burst of requests, you can set the bucket size to 1.
 
 |Config          | Description |
 |----------------|-------------|
 | bucket_size	 | Max amount of tokens that can be accumulated. |
-| period	     | The refresh period for the tokens, it can be: second, minute or hour |
-| refresh_rate	 | The number of tokens leaked on every refresh period. Default: 1 |
-
-As it can be interpreted from this description, this algorithm is more network intensive than the previous one because we need to constantly query the bucket to figure out if there is room when is full.
+| refresh_rate	 | The number of milliseconds to wait until a token is leaked. Default: 1000 |
 
 Writes have no effect on this slot. Reads will return 1 if the token was accepted or zero if not.
 

--- a/internal/slots/leaky_bucket.go
+++ b/internal/slots/leaky_bucket.go
@@ -1,0 +1,73 @@
+package slots
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/dankomiocevic/ghoti/internal/auth"
+)
+
+type leakyBucketSlot struct {
+	users  map[string]string
+	value  int64
+	size   int64
+	rate   int
+	window int64
+	mu     sync.Mutex
+}
+
+func newLeakyBucketSlot(bucketSize, refreshRate int, users map[string]string) (*leakyBucketSlot, error) {
+	if bucketSize < 1 {
+		return nil, fmt.Errorf("Bucket size must be bigger than zero")
+	}
+
+	if refreshRate < 1 {
+		return nil, fmt.Errorf("Refresh rate cannot be zero")
+	}
+
+	return &leakyBucketSlot{value: 0, size: int64(bucketSize), rate: refreshRate, window: currentWindowMillis(refreshRate), users: users}, nil
+}
+
+func currentWindowMillis(rate int) int64 {
+	return time.Now().UnixMilli() / int64(rate)
+}
+
+func (m *leakyBucketSlot) Read() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	current := currentWindowMillis(m.rate)
+	windowDiff := current - m.window
+	if windowDiff > m.size {
+		m.window = current
+		m.value = 0
+	} else {
+		m.window = current
+		m.value = max(0, m.value-windowDiff)
+	}
+
+	if m.value == m.size {
+		return "0"
+	} else {
+		m.value = min(m.size, m.value+1)
+		return "1"
+	}
+}
+
+func (m *leakyBucketSlot) CanRead(u *auth.User) bool {
+	if len(m.users) == 0 {
+		return true
+	}
+
+	return m.users[u.Name] == "r" || m.users[u.Name] == "a"
+}
+
+func (m *leakyBucketSlot) CanWrite(u *auth.User) bool {
+	return false
+}
+
+func (m *leakyBucketSlot) Write(data string, from net.Conn) (string, error) {
+	return "", fmt.Errorf("Token bucket slots cannot be used to write")
+}

--- a/internal/slots/leaky_bucket_test.go
+++ b/internal/slots/leaky_bucket_test.go
@@ -1,0 +1,121 @@
+package slots
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dankomiocevic/ghoti/internal/auth"
+	"github.com/spf13/viper"
+)
+
+func loadLeakySlot(t *testing.T) Slot {
+	v := viper.New()
+
+	v.Set("kind", "leaky_bucket")
+	v.Set("bucket_size", 200)
+	v.Set("refresh_rate", 100)
+	v.Set("users.read", "r")
+	v.Set("users.write", "w")
+	v.Set("users.allu", "a")
+
+	slot, err := GetSlot(v)
+	if err != nil {
+		t.Fatalf("Slot must not return error: %s", err)
+	}
+	return slot
+}
+
+func TestLeakyBucketSmoke(t *testing.T) {
+	slot := loadLeakySlot(t)
+
+	leakySlot := slot.(*leakyBucketSlot)
+	if leakySlot.value != 0 {
+		t.Errorf("Bucket must be started with 0 value: %d", leakySlot.value)
+	}
+}
+
+func TestLeakyBucketRead(t *testing.T) {
+	read_user, _ := auth.GetUser("read", "pass")
+	write_user, _ := auth.GetUser("write", "pass")
+	all_user, _ := auth.GetUser("allu", "pass")
+
+	slot := loadLeakySlot(t)
+	if !slot.CanRead(&read_user) {
+		t.Fatalf("we should be able to read with the read user")
+	}
+
+	if slot.CanRead(&write_user) {
+		t.Fatalf("we should not be able to read with the read user")
+	}
+
+	if !slot.CanRead(&all_user) {
+		t.Fatalf("we should be able to read with the read/write user")
+	}
+}
+
+func TestLeakyBucketWrite(t *testing.T) {
+	read_user, _ := auth.GetUser("read", "pass")
+	write_user, _ := auth.GetUser("write", "pass")
+	all_user, _ := auth.GetUser("allu", "pass")
+
+	slot := loadLeakySlot(t)
+	if slot.CanWrite(&read_user) {
+		t.Fatalf("we should not be able to write with the read user")
+	}
+
+	if slot.CanWrite(&write_user) {
+		t.Fatalf("we should not be able to write with the write user")
+	}
+
+	if slot.CanWrite(&all_user) {
+		t.Fatalf("we should not be able to write with the read/write user")
+	}
+}
+
+func TestLeakyBucketMissingConfig(t *testing.T) {
+	v := viper.New()
+
+	v.Set("kind", "leaky_bucket")
+	_, err := GetSlot(v)
+
+	if err == nil {
+		t.Fatalf("Slot must return error")
+	}
+}
+
+func TestLeakyBucketInvalidConfig(t *testing.T) {
+	v := viper.New()
+
+	v.Set("kind", "leaky_bucket")
+	v.Set("bucket_size", 0)
+	_, err := GetSlot(v)
+
+	if err == nil {
+		t.Fatalf("Slot must return error")
+	}
+}
+
+func TestLeakyBucketUseAllTokens(t *testing.T) {
+	slot := loadLeakySlot(t)
+
+	leakySlot := slot.(*leakyBucketSlot)
+	for i := 0; i < 200; i++ {
+		if leakySlot.Read() != "1" {
+			t.Fatalf("Failed on %d, we should be able to read all tokens", i)
+		}
+	}
+
+	if leakySlot.Read() != "0" {
+		t.Fatalf("We should not be able to read more tokens")
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	if leakySlot.Read() != "1" {
+		t.Fatalf("We should be able to read tokens again")
+	}
+
+	if leakySlot.Read() != "0" {
+		t.Fatalf("We should not be able to read more tokens")
+	}
+}

--- a/internal/slots/slots.go
+++ b/internal/slots/slots.go
@@ -72,5 +72,24 @@ func GetSlot(v *viper.Viper) (Slot, error) {
 		return tokenBucket, nil
 	}
 
+	if kind == "leaky_bucket" {
+		if !v.IsSet("bucket_size") {
+			return nil, fmt.Errorf("bucket_size must be set for token_bucket slot")
+		}
+		bucketSize := v.GetInt("bucket_size")
+
+		refreshRate := 1000
+		if v.IsSet("refresh_rate") {
+			refreshRate = v.GetInt("refresh_rate")
+		}
+
+		leakyBucket, err := newLeakyBucketSlot(bucketSize, refreshRate, users)
+		if err != nil {
+			return nil, err
+		}
+
+		return leakyBucket, nil
+	}
+
 	return nil, errors.New("Invalid kind of slot")
 }


### PR DESCRIPTION
This pull request introduces a new leaky bucket rate limiter feature, which includes updates to the documentation, implementation of the leaky bucket logic, and corresponding unit tests.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L146-R157): Updated the leaky bucket limiter section to provide a detailed explanation of the algorithm and its configuration parameters.

### Implementation:
* [`internal/slots/leaky_bucket.go`](diffhunk://#diff-e15c869b6d6424f48089deb1fc44d2c887c675deb90e48cd80b0ec9a576fcd26R1-R73): Added the `leakyBucketSlot` struct and its methods to implement the leaky bucket rate limiter.
* [`internal/slots/slots.go`](diffhunk://#diff-2ac0d3ea5b0fcb5f7e98ab6313bc8f69f8806ce61bf1a682ec55449a5a103e11R75-R93): Modified the `GetSlot` function to support the creation of a leaky bucket slot based on configuration.

### Testing:
* [`internal/slots/leaky_bucket_test.go`](diffhunk://#diff-8b1723857f31ed61a7e50821e3a6974f6336e40beb8259b387201287811e7913R1-R121): Added unit tests for the leaky bucket rate limiter to ensure correct functionality, including tests for reading, writing, configuration validation, and token consumption.