### PR TITLE
Add ticker slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ The bucket size allows applications to have a burst of requests but after some t
 
 Writes have no effect on this slot. Reads will return 1 if the token was accepted or zero if not.
 
+Example config:
+```yaml
+slot_003:
+  type: leaky_bucket
+  bucket_size: 100
+  refresh_rate: 1000
+```
+
 ### Broadcast signal propagation (TBD)
 
 Anything sent to this slot is propagated as a message to all the other clients. Any client connected to Ghoti at this point will receive the event at least once.
@@ -205,15 +213,26 @@ It has the same configuration as the previous slot:
 | dereg_tries    | Number of messages that are tried on a client until is de-registered. |
 
 
-### Ticker (watchdog) (TBD)
+### Ticker (watchdog)
 
 This is a classic slot used in embedded circuits and microcontrollers, the slot contains an integer value, the way this works is that the slot will tick once a second making its value go down by one until it reaches zero.
 If any client writes to this slot and sets a value (integer value), it will start decrementing that value once a second until it reaches zero again.
 
 In other words, if a client writes `600` on this slot, then waits 9 minutes and reads the value, the value will be `60`. After one more minute, the value will be zero.
 
-There is no configuration needed for this slot.
+|Config          | Description |
+|----------------|-------------|
+| initial_value  | Initial value for the ticker. Default: 0 |
+| refresh_rate	 | The number of milliseconds per tick. Default: 1000 |
 
+Example config:
+
+```yaml
+slot_003:
+  type: ticker
+  initial_value: 600
+  refresh_rate: 1000
+```
 
 ### Atomic counter slot (TBD)
 

--- a/internal/slots/slots.go
+++ b/internal/slots/slots.go
@@ -91,5 +91,32 @@ func GetSlot(v *viper.Viper) (Slot, error) {
 		return leakyBucket, nil
 	}
 
+	if kind == "ticker" {
+		initialValue := 0
+		if !v.IsSet("initial_value") {
+			return nil, fmt.Errorf("initial_value must be set for ticker slot")
+		} else {
+			initialValue = v.GetInt("initial_value")
+		}
+
+		if initialValue < 0 {
+			return nil, fmt.Errorf("Initial value cannot be negative")
+		}
+
+		refreshRate := 1000
+		if !v.IsSet("refresh_rate") {
+			return nil, fmt.Errorf("refresh_rate must be set for ticker slot")
+		} else {
+			refreshRate = v.GetInt("refresh_rate")
+		}
+
+		tickerSlot, err := newTickerSlot(refreshRate, initialValue, users)
+		if err != nil {
+			return nil, err
+		}
+
+		return tickerSlot, nil
+	}
+
 	return nil, errors.New("Invalid kind of slot")
 }

--- a/internal/slots/ticker.go
+++ b/internal/slots/ticker.go
@@ -1,0 +1,74 @@
+package slots
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"sync"
+
+	"github.com/dankomiocevic/ghoti/internal/auth"
+)
+
+type tickerSlot struct {
+	users  map[string]string
+	value  int64
+	size   int64
+	rate   int
+	window int64
+	mu     sync.Mutex
+}
+
+func newTickerSlot(refreshRate, initialValue int, users map[string]string) (*tickerSlot, error) {
+	if refreshRate < 1 {
+		return nil, fmt.Errorf("Refresh rate cannot be zero")
+	}
+
+	if initialValue < 0 {
+		return nil, fmt.Errorf("Initial value cannot be negative")
+	}
+
+	return &tickerSlot{value: int64(initialValue), rate: refreshRate, window: currentWindowMillis(refreshRate), users: users}, nil
+}
+
+func (m *tickerSlot) Read() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	current := currentWindowMillis(m.rate)
+	windowDiff := current - m.window
+	m.window = current
+	m.value = max(0, m.value-windowDiff)
+
+	return strconv.Itoa(int(m.value))
+}
+
+func (m *tickerSlot) CanRead(u *auth.User) bool {
+	if len(m.users) == 0 {
+		return true
+	}
+
+	return m.users[u.Name] == "r" || m.users[u.Name] == "a"
+}
+
+func (m *tickerSlot) CanWrite(u *auth.User) bool {
+	if len(m.users) == 0 {
+		return true
+	}
+
+	return m.users[u.Name] == "w" || m.users[u.Name] == "a"
+}
+
+func (m *tickerSlot) Write(data string, from net.Conn) (string, error) {
+	dataInt, err := strconv.Atoi(data)
+	if err != nil {
+		return "", fmt.Errorf("Data must be an integer")
+	}
+
+	if dataInt < 0 {
+		return "", fmt.Errorf("Data cannot be negative")
+	}
+
+	m.window = currentWindowMillis(m.rate)
+	m.value = int64(dataInt)
+	return strconv.Itoa(dataInt), nil
+}

--- a/internal/slots/ticker_test.go
+++ b/internal/slots/ticker_test.go
@@ -1,0 +1,118 @@
+package slots
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dankomiocevic/ghoti/internal/auth"
+	"github.com/spf13/viper"
+)
+
+func loadTickerSlot(t *testing.T) Slot {
+	v := viper.New()
+
+	v.Set("kind", "ticker")
+	v.Set("initial_value", 200)
+	v.Set("refresh_rate", 100)
+	v.Set("users.read", "r")
+	v.Set("users.write", "w")
+	v.Set("users.allu", "a")
+
+	slot, err := GetSlot(v)
+	if err != nil {
+		t.Fatalf("Slot must not return error: %s", err)
+	}
+	return slot
+}
+
+func TestTickerSmoke(t *testing.T) {
+	slot := loadTickerSlot(t)
+
+	tickerSlot := slot.(*tickerSlot)
+	if tickerSlot.value != 200 {
+		t.Errorf("Ticker must be started with 200 value: %d", tickerSlot.value)
+	}
+}
+
+func TestTickerRead(t *testing.T) {
+	read_user, _ := auth.GetUser("read", "pass")
+	write_user, _ := auth.GetUser("write", "pass")
+	all_user, _ := auth.GetUser("allu", "pass")
+
+	slot := loadTickerSlot(t)
+	if !slot.CanRead(&read_user) {
+		t.Fatalf("we should be able to read with the read user")
+	}
+
+	if slot.CanRead(&write_user) {
+		t.Fatalf("we should not be able to read with the write user")
+	}
+
+	if !slot.CanRead(&all_user) {
+		t.Fatalf("we should be able to read with the read/write user")
+	}
+}
+
+func TestTickerWritePermissions(t *testing.T) {
+	read_user, _ := auth.GetUser("read", "pass")
+	write_user, _ := auth.GetUser("write", "pass")
+	all_user, _ := auth.GetUser("allu", "pass")
+
+	slot := loadTickerSlot(t)
+
+	if slot.CanWrite(&read_user) {
+		t.Fatalf("we should not be able to write with the read user")
+	}
+
+	if !slot.CanWrite(&write_user) {
+		t.Fatalf("we should be able to write with the write user")
+	}
+
+	if !slot.CanWrite(&all_user) {
+		t.Fatalf("we should be able to write with the read/write user")
+	}
+}
+
+func TestTickerWrite(t *testing.T) {
+	slot := loadTickerSlot(t)
+
+	slot.Write("100", nil)
+	if slot.Read() != "100" {
+		t.Fatalf("Value must be 100")
+	}
+
+	slot.Write("0", nil)
+	if slot.Read() != "0" {
+		t.Fatalf("Value must be 0")
+	}
+
+	_, err := slot.Write("-1", nil)
+	if err == nil {
+		t.Fatalf("Error must be returned when storing negative value")
+	}
+}
+
+func TestTickerTick(t *testing.T) {
+	slot := loadTickerSlot(t)
+
+	slot.Write("100", nil)
+	if slot.Read() != "100" {
+		t.Fatalf("Value must be 100")
+	}
+
+	time.Sleep(101 * time.Millisecond)
+	if slot.Read() != "99" {
+		t.Fatalf("Value must be 99")
+	}
+}
+
+func TestTickerMissingConfig(t *testing.T) {
+	v := viper.New()
+
+	v.Set("kind", "ticker")
+	_, err := GetSlot(v)
+
+	if err == nil {
+		t.Fatalf("Slot must return error")
+	}
+}


### PR DESCRIPTION
This pull request introduces a new `ticker` slot type to the application. The changes include updates to the documentation, the addition of the ticker slot implementation, and corresponding tests.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R161-R168): Added configuration examples for the `leaky_bucket` and `ticker` slots. Updated the description and configuration details for the `ticker` slot. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R161-R168) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L208-R235)

### Implementation of Ticker Slot:
* [`internal/slots/slots.go`](diffhunk://#diff-2ac0d3ea5b0fcb5f7e98ab6313bc8f69f8806ce61bf1a682ec55449a5a103e11R94-R120): Added logic to handle the creation of a `ticker` slot, including validation for `initial_value` and `refresh_rate`.
* [`internal/slots/ticker.go`](diffhunk://#diff-be43318241966c6f8216039115f41abaebceecf525f7aeffa8fd91f13bb4fab6R1-R74): Implemented the `tickerSlot` struct and its methods, including `Read`, `CanRead`, `CanWrite`, and `Write`.

### Testing:
* [`internal/slots/ticker_test.go`](diffhunk://#diff-c6be442c7c4ee7523264acca098ec52bf7e1ab3622026e9a9e5d60d0a87d0759R1-R118): Added tests for the `ticker` slot, covering initialization, read/write permissions, ticking behavior, and handling of missing configuration.