### PR TITLE
First pass at removing the big server method

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,10 +60,6 @@ func LoadConfig() (*Config, error) {
 		return nil, fmt.Errorf("failed to load server config: %w", err)
 	}
 
-	if err := viper.Unmarshal(config); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal server config: %w", err)
-	}
-
 	if viper.IsSet("addr") {
 		config.TcpAddr = viper.GetString("addr")
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -141,74 +141,22 @@ func (s *Server) handleUserConnection(conn Connection) {
 		}
 
 		if msg.Command == 'u' {
-			err := auth.ValidateUsername(msg.Value)
+			err = processUsername(s, &conn, msg)
 			if err != nil {
-				res := errors.Error("WRONG_USER")
-				c.Write([]byte(res.Response()))
-				slog.Debug("Invalid user received",
-					slog.String("user", msg.Value),
-					slog.String("id", conn.Id),
-					slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
-				)
-				slog.Debug("Disconnecting", slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()))
-				return
-			} else {
-				conn.LoggedUser = auth.User{}
-				conn.Username = msg.Value
-				conn.IsLogged = false
-
-				var sb strings.Builder
-				sb.WriteString("v")
-				sb.WriteString(conn.Username)
-				sb.WriteString("\n")
-				c.Write([]byte(sb.String()))
-				slog.Debug("Username set for connection",
-					slog.String("user", conn.Username),
-					slog.String("id", conn.Id),
-					slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
-				)
+				switch err.(type) {
+				case errors.PermanentError:
+					return
+				}
 			}
 			continue
 		}
 
 		if msg.Command == 'p' {
-			user, err := auth.GetUser(conn.Username, msg.Value)
+			err = processPassword(s, &conn, msg)
 			if err != nil {
-				res := errors.Error("WRONG_PASS")
-				c.Write([]byte(res.Response()))
-				slog.Debug("Invalid password received",
-					slog.String("id", conn.Id),
-					slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
-				)
-				slog.Debug("Disconnecting",
-					slog.String("id", conn.Id),
-					slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
-				)
-				return
-			} else {
-				if s.usersMap[user.Name].Password != user.Password {
-					res := errors.Error("WRONG_LOGIN")
-					c.Write([]byte(res.Response()))
-					slog.Warn("Invalid login received",
-						slog.String("id", conn.Id),
-						slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
-					)
-					slog.Debug("Disconnecting", slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()))
+				switch err.(type) {
+				case errors.PermanentError:
 					return
-				} else {
-					conn.LoggedUser = user
-					conn.IsLogged = true
-
-					var sb strings.Builder
-					sb.WriteString("v")
-					sb.WriteString(conn.Username)
-					sb.WriteString("\n")
-					c.Write([]byte(sb.String()))
-					slog.Debug("User logged in for connection",
-						slog.String("user", conn.Username),
-						slog.String("id", conn.Id),
-						slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
-					)
 				}
 			}
 			continue
@@ -323,4 +271,84 @@ func (s *Server) handleUserConnection(conn Connection) {
 			)
 		}
 	}
+}
+
+func processUsername(s *Server, conn *Connection, msg Message) error {
+	err := auth.ValidateUsername(msg.Value)
+	if err != nil {
+		res := errors.Error("WRONG_USER")
+		conn.SendEvent(res.Response())
+		slog.Debug("Invalid user received",
+			slog.String("user", msg.Value),
+			slog.String("id", conn.Id),
+			slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
+		)
+		slog.Debug("Disconnecting", slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()))
+		return errors.PermanentError{Err: "Bad password"}
+	} else {
+		conn.LoggedUser = auth.User{}
+		conn.Username = msg.Value
+		conn.IsLogged = false
+
+		var sb strings.Builder
+		sb.WriteString("v")
+		sb.WriteString(conn.Username)
+		sb.WriteString("\n")
+		err = conn.SendEvent(sb.String())
+		if err != nil {
+			return err
+		}
+		slog.Debug("Username set for connection",
+			slog.String("user", conn.Username),
+			slog.String("id", conn.Id),
+			slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
+		)
+	}
+	return nil
+}
+
+func processPassword(s *Server, conn *Connection, msg Message) error {
+	user, err := auth.GetUser(conn.Username, msg.Value)
+	if err != nil {
+		res := errors.Error("WRONG_PASS")
+		conn.SendEvent(res.Response())
+		slog.Debug("Invalid password received",
+			slog.String("id", conn.Id),
+			slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
+		)
+		slog.Debug("Disconnecting",
+			slog.String("id", conn.Id),
+			slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
+		)
+		return errors.PermanentError{Err: "Bad password"}
+	} else {
+		if s.usersMap[user.Name].Password != user.Password {
+			res := errors.Error("WRONG_LOGIN")
+			conn.SendEvent(res.Response())
+			slog.Warn("Invalid login received",
+				slog.String("id", conn.Id),
+				slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
+			)
+			slog.Debug("Disconnecting", slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()))
+			return errors.PermanentError{Err: "Invalid login"}
+		} else {
+			conn.LoggedUser = user
+			conn.IsLogged = true
+
+			var sb strings.Builder
+			sb.WriteString("v")
+			sb.WriteString(conn.Username)
+			sb.WriteString("\n")
+			err = conn.SendEvent(sb.String())
+			if err != nil {
+				return err
+			}
+			slog.Debug("User logged in for connection",
+				slog.String("user", conn.Username),
+				slog.String("id", conn.Id),
+				slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
+			)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
This pull request includes several changes to the configuration loading and testing process, as well as improvements to the server's handling of user connections. The most important changes include the refactoring of configuration tests to use a more structured approach, and the enhancement of error handling in the server connection logic.

Improvements to configuration tests:

* [`internal/config/config_test.go`](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62R5-R56): Refactored multiple tests to use the `resetViper` function with a structured YAML configuration string, simplifying the setup process and improving readability. [[1]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62R5-R56) [[2]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L44-R76) [[3]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L58-R92) [[4]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L73-R107) [[5]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L89-R123) [[6]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L102-R137) [[7]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L119-R155) [[8]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L132-R170) [[9]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L162-R207) [[10]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L204-R250) [[11]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L221-R269) [[12]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L238-R288) [[13]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L255-R308) [[14]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L273-R327) [[15]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L290-R346) [[16]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L311-L313) [[17]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L327-L329) [[18]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L339-L341) [[19]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L355-R447)

Enhancements to server connection error handling:

* [`internal/server/server.go`](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23L135-R141): Improved error handling by replacing direct calls to `c.Write` with `conn.SendEvent`, and adding error type checks to handle `PermanentError` cases more gracefully. [[1]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23L135-R141) [[2]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23L144-L211) [[3]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23L220-R180) [[4]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23L238-R204) [[5]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23L250-R222)

Removal of unnecessary unmarshalling:

* [`internal/config/config.go`](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL63-L66): Removed redundant unmarshalling of the server configuration, as it was not needed.