### PR TITLE
Refactoring the big method in server

### DIFF
--- a/internal/errors/connection_errors.go
+++ b/internal/errors/connection_errors.go
@@ -8,18 +8,10 @@ func (e TranscientError) Error() string {
 	return e.Err
 }
 
-func (e TranscientError) String() string {
-	return e.Err
-}
-
 type PermanentError struct {
 	Err string
 }
 
 func (e PermanentError) Error() string {
-	return e.Err
-}
-
-func (e PermanentError) String() string {
 	return e.Err
 }

--- a/internal/errors/connection_errors.go
+++ b/internal/errors/connection_errors.go
@@ -8,10 +8,18 @@ func (e TranscientError) Error() string {
 	return e.Err
 }
 
+func (e TranscientError) String() string {
+	return e.Err
+}
+
 type PermanentError struct {
 	Err string
 }
 
 func (e PermanentError) Error() string {
+	return e.Err
+}
+
+func (e PermanentError) String() string {
 	return e.Err
 }

--- a/internal/server/connection.go
+++ b/internal/server/connection.go
@@ -125,7 +125,7 @@ func (c *Connection) EventProcessor() {
 
 		c.NetworkConn.SetWriteDeadline(event.timeout)
 		_, err := c.NetworkConn.Write([]byte(event.data))
-		if err != nil {
+		if err != nil { //TODO: Improve error handling to differentiate error types
 			event.callback <- event.id + " ERROR"
 			continue
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -266,12 +266,7 @@ func (s *Server) handleUserConnection(conn Connection) {
 			}
 		}
 
-		var sb strings.Builder
-		sb.WriteString("v")
-		sb.WriteString(fmt.Sprintf("%03d", msg.Slot))
-		sb.WriteString(value)
-		sb.WriteString("\n")
-		err = conn.SendEvent(sb.String())
+		err = sendSlotData(msg, conn, value)
 		if err != nil {
 			slog.Error("Error sending event to connection",
 				slog.String("id", conn.Id),
@@ -286,15 +281,27 @@ func (s *Server) handleUserConnection(conn Connection) {
 					slog.String("id", conn.Id),
 					slog.Any("error", err))
 			}
-		} else {
-			slog.Debug("Value read from slot",
-				slog.Int("slot", msg.Slot),
-				slog.String("value", value),
-				slog.String("id", conn.Id),
-				slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
-			)
 		}
 	}
+}
+
+func sendSlotData(msg Message, conn Connection, value string) error {
+	var sb strings.Builder
+	sb.WriteString("v")
+	sb.WriteString(fmt.Sprintf("%03d", msg.Slot))
+	sb.WriteString(value)
+	sb.WriteString("\n")
+	err := conn.SendEvent(sb.String())
+	if err != nil {
+		return err
+	}
+	slog.Debug("Value read from slot",
+		slog.Int("slot", msg.Slot),
+		slog.String("value", value),
+		slog.String("id", conn.Id),
+		slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
+	)
+	return nil
 }
 
 func processUsername(s *Server, conn *Connection, msg Message) error {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -108,7 +108,6 @@ func (s *Server) handleUserConnection(conn Connection) {
 	)
 
 	go conn.EventProcessor()
-	c := conn.NetworkConn
 	for {
 		select {
 		case <-conn.Quit:
@@ -129,6 +128,8 @@ func (s *Server) handleUserConnection(conn Connection) {
 					slog.Any("error", err))
 			}
 		}
+		current_slot := s.slotsArray[msg.Slot]
+
 		if msg.Command == 'q' {
 			slog.Debug("Client disconnected",
 				slog.String("id", conn.Id),
@@ -138,149 +139,116 @@ func (s *Server) handleUserConnection(conn Connection) {
 		}
 		if !s.cluster.IsLeader() {
 			res := errors.Error("NOT_LEADER")
-			err = conn.SendEvent(res.Response() + s.cluster.GetLeader())
-			if err != nil {
-				switch err.(type) {
-				case errors.PermanentError:
-					return
-				}
-			}
 			slog.Debug("Request made to node that was not leader",
 				slog.String("id", conn.Id),
 				slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
 			)
-			continue
+			err = conn.SendEvent(res.Response() + s.cluster.GetLeader())
+			goto handleError
 		}
 
 		if msg.Command == 'u' {
 			err = processUsername(s, &conn, msg)
-			if err != nil {
-				switch err.(type) {
-				case errors.PermanentError:
-					return
-				}
-			}
-			continue
+			goto handleError
 		}
 
 		if msg.Command == 'p' {
 			err = processPassword(s, &conn, msg)
-			if err != nil {
-				switch err.(type) {
-				case errors.PermanentError:
-					return
-				}
-			}
-			continue
+			goto handleError
 		}
 
-		current_slot := s.slotsArray[msg.Slot]
 		if current_slot == nil {
 			res := errors.Error("MISSING_SLOT")
-			err = conn.SendEvent(res.Response())
-			if err != nil {
-				switch err.(type) {
-				case errors.PermanentError:
-					return
-				}
-			}
 			slog.Debug("Missing slot",
 				slog.Int("slot", msg.Slot),
 				slog.String("id", conn.Id),
 				slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
 			)
-			continue
+			err = conn.SendEvent(res.Response())
+			goto handleError
 		}
 
-		var value string
 		if msg.Command == 'w' {
-			if !current_slot.CanWrite(&conn.LoggedUser) {
-				slog.Info("Connection trying to write on slot without permission",
-					slog.Int("slot", msg.Slot),
-					slog.String("id", conn.Id),
-					slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
-				)
-				res := errors.Error("WRITE_PERMISSION")
-				err = conn.SendEvent(res.Response())
-				if err != nil {
-					switch err.(type) {
-					case errors.PermanentError:
-						return
-					}
-				}
-				continue
-			}
-
-			value, err = current_slot.Write(msg.Value, c)
-
-			if err != nil {
-				res := errors.Error("WRITE_FAILED")
-				slog.Error("Error writing in slot",
-					slog.Int("slot", msg.Slot),
-					slog.Any("error", err),
-				)
-				err = conn.SendEvent(res.Response())
-				if err != nil {
-					switch err.(type) {
-					case errors.PermanentError:
-						return
-					}
-				}
-				continue
-			} else {
-				slog.Debug("Value written in slot",
-					slog.Int("slot", msg.Slot),
-					slog.String("value", msg.Value),
-					slog.String("id", conn.Id),
-					slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
-				)
-			}
-		} else if msg.Command == 'r' {
-			if current_slot.CanRead(&conn.LoggedUser) {
-				value = current_slot.Read()
-			} else {
-				slog.Info("Connection trying to read on slot without permission",
-					slog.Int("slot", msg.Slot),
-					slog.String("id", conn.Id),
-					slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
-				)
-				res := errors.Error("READ_PERMISSION")
-				err = conn.SendEvent(res.Response())
-				if err != nil {
-					slog.Error("Error sending event to connection",
-						slog.String("id", conn.Id),
-						slog.Any("error", err))
-					switch err.(type) {
-					case errors.TranscientError:
-						continue
-					case errors.PermanentError:
-						return
-					default:
-						slog.Error("Unidentified error writing message",
-							slog.String("id", conn.Id),
-							slog.Any("error", err))
-					}
-				}
-				continue
-			}
+			err = processWrite(conn, current_slot, msg)
+			goto handleError
 		}
 
-		err = sendSlotData(msg, conn, value)
+		if msg.Command == 'r' {
+			err = processRead(conn, current_slot, msg)
+			goto handleError
+		}
+
+	handleError:
 		if err != nil {
-			slog.Error("Error sending event to connection",
-				slog.String("id", conn.Id),
-				slog.Any("error", err))
 			switch err.(type) {
 			case errors.TranscientError:
+				slog.Error(err.Error(),
+					slog.String("id", conn.Id))
 				continue
 			case errors.PermanentError:
+				slog.Error(err.Error(),
+					slog.String("id", conn.Id))
 				return
 			default:
-				slog.Error("Unidentified error writing message",
+				slog.Error("Unidentified error type",
 					slog.String("id", conn.Id),
 					slog.Any("error", err))
 			}
 		}
+	}
+}
+
+func processRead(conn Connection, current_slot slots.Slot, msg Message) error {
+	if current_slot.CanRead(&conn.LoggedUser) {
+		value := current_slot.Read()
+		err := sendSlotData(msg, conn, value)
+		return err
+	} else {
+		slog.Error("Connection trying to read on slot without permission",
+			slog.Int("slot", msg.Slot),
+			slog.String("id", conn.Id),
+			slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
+		)
+		res := errors.Error("READ_PERMISSION")
+		err := conn.SendEvent(res.Response())
+		return err
+	}
+}
+
+func processWrite(conn Connection, current_slot slots.Slot, msg Message) error {
+	if !current_slot.CanWrite(&conn.LoggedUser) {
+		slog.Info("Connection trying to write on slot without permission",
+			slog.Int("slot", msg.Slot),
+			slog.String("id", conn.Id),
+			slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
+		)
+		res := errors.Error("WRITE_PERMISSION")
+		err := conn.SendEvent(res.Response())
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	value, err := current_slot.Write(msg.Value, conn.NetworkConn)
+
+	if err != nil {
+		res := errors.Error("WRITE_FAILED")
+		slog.Error("Error writing in slot",
+			slog.Int("slot", msg.Slot),
+			slog.Any("error", err),
+		)
+		err = conn.SendEvent(res.Response())
+		return err
+	} else {
+		slog.Debug("Value written in slot",
+			slog.Int("slot", msg.Slot),
+			slog.String("value", msg.Value),
+			slog.String("id", conn.Id),
+			slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
+		)
+		err = sendSlotData(msg, conn, value)
+		return err
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -129,8 +129,14 @@ func (s *Server) handleUserConnection(conn Connection) {
 					slog.Any("error", err))
 			}
 		}
-
-		if msg.Command != 'q' && !s.cluster.IsLeader() {
+		if msg.Command == 'q' {
+			slog.Debug("Client disconnected",
+				slog.String("id", conn.Id),
+				slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
+			)
+			return
+		}
+		if !s.cluster.IsLeader() {
 			res := errors.Error("NOT_LEADER")
 			err = conn.SendEvent(res.Response() + s.cluster.GetLeader())
 			if err != nil {
@@ -229,13 +235,6 @@ func (s *Server) handleUserConnection(conn Connection) {
 					slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
 				)
 			}
-
-		} else if msg.Command == 'q' {
-			slog.Debug("Client disconnected",
-				slog.String("id", conn.Id),
-				slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
-			)
-			return
 		} else if msg.Command == 'r' {
 			if current_slot.CanRead(&conn.LoggedUser) {
 				value = current_slot.Read()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -96,9 +96,6 @@ func (s *Server) Stop() {
 	s.wg.Wait()
 }
 
-// TODO: Refactor this into smaller functions
-// TODO: Improve error handling
-// TODO: Remove missing direct conn.Write calls
 func (s *Server) handleUserConnection(conn Connection) {
 	defer s.connections.Delete(conn.Id)
 	defer conn.Close()


### PR DESCRIPTION
This pull request refactors the server main function to handle connections to make it shorter and easier to read.
It also adds better handling of configuration tests to use a in-memory file system to make it more E2E.

It fixes a bug with the configuration that was preventing to configure users.

Improvements to configuration loading and testing:

* [`internal/config/config_test.go`](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62R5-R56): Refactored the `resetViper` function to use an in-memory file system for configuration files, and updated all tests to use the new `resetViper` function with configuration data as a string parameter. [[1]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62R5-R56) [[2]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L44-R76) [[3]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L58-R92) [[4]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L73-R107) [[5]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L89-R123) [[6]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L102-R137) [[7]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L119-R155) [[8]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L132-R170) [[9]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L162-R207) [[10]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L204-R250) [[11]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L221-R269) [[12]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L238-R288) [[13]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L255-R308) [[14]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L273-R327) [[15]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L290-R346) [[16]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L311-L313) [[17]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L327-L329) [[18]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L339-L341) [[19]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L355-R447)

Other changes:

* [`internal/config/config.go`](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL63-L66): Removed unnecessary unmarshalling of server configuration.
* [`internal/server/connection.go`](diffhunk://#diff-b45e6aebc775da6c911eb9e29019ad74833e453a28a7007a008100cdaf62c268L128-R128): Added a TODO comment to improve error handling in the `EventProcessor` method.
* [`internal/server/server.go`](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23L111): Refactored