### PR TITLE
Add missing ghoti files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,4 @@
 go.work
 
 # Buids
-ghoti
 dist/

--- a/cmd/ghoti/main.go
+++ b/cmd/ghoti/main.go
@@ -1,0 +1,27 @@
+// Package main contains the root of all commands.
+package main
+
+import (
+	"os"
+
+	"github.com/dankomiocevic/ghoti/cmd"
+	"github.com/dankomiocevic/ghoti/cmd/benchmark"
+	"github.com/dankomiocevic/ghoti/cmd/run"
+)
+
+func main() {
+	rootCmd := cmd.NewRootCommand()
+
+	runCmd := run.NewRunCommand()
+	rootCmd.AddCommand(runCmd)
+
+	benchmarkCmd := benchmark.NewBenchmarkCommand()
+	rootCmd.AddCommand(benchmarkCmd)
+
+	versionCmd := cmd.NewVersionCommand()
+	rootCmd.AddCommand(versionCmd)
+
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
This pull request introduces the main entry point for the `ghoti` CLI application by adding a new `main.go` file. The file sets up the root command and integrates subcommands for running tasks, benchmarking, and displaying the version.

Key changes:

* **New entry point for the CLI application:**
  - Added `cmd/ghoti/main.go` as the main entry point for the `ghoti` CLI. This file initializes the root command and registers the `run`, `benchmark`, and `version` subcommands.