### PR TITLE
Add release workflows

### DIFF
--- a/.github/workflows/go-pkg-update.yml
+++ b/.github/workflows/go-pkg-update.yml
@@ -1,0 +1,46 @@
+name: Update pkg.go.dev
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types:
+      - completed
+
+jobs:
+  update-pkg-go-dev:
+    name: Update pkg.go.dev
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22'
+
+      - name: Get latest tag
+        id: get_tag
+        run: |
+          TAG=$(git describe --tags --abbrev=0)
+          echo "TAG=${TAG}" >> $GITHUB_ENV
+          echo "Latest tag: ${TAG}"
+
+      - name: Update pkg.go.dev
+        run: |
+          echo "Requesting pkg.go.dev to update for version ${TAG}"
+          go list -m github.com/dankomiocevic/ghoti@${TAG}
+          
+          # Force proxy.golang.org to update
+          GOPROXY=https://proxy.golang.org go list -m github.com/dankomiocevic/ghoti@${TAG}
+          
+          echo "Waiting for propagation..."
+          sleep 10
+          
+          # Verify versions are available
+          go list -m -versions github.com/dankomiocevic/ghoti
+          
+          echo "✅ pkg.go.dev update requested for ${TAG}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+# Add explicit permissions
+permissions:
+  contents: write  # Required for creating releases
+
+jobs:
+  build:
+    name: Build and Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22'
+
+      - name: Get version from tag
+        id: get_version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
+      - name: Build and create release packages
+        run: make release VERSION=${{ env.VERSION }}
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            ./dist/*.zip
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+          body: |
+            # Ghoti v${{ env.VERSION }}
+            
+            ## Installation
+            
+            1. Download the appropriate zip file for your platform
+            2. Extract the contents
+            3. Run the `ghoti` executable (or `ghoti.exe` on Windows)
+            
+            ## Included Files
+            
+            - ghoti executable for your platform
+            - README.md with usage instructions
+            
+            ## Platform-specific Notes
+            
+            ### Linux
+            Make the file executable with `chmod +x ghoti` if needed
+            
+            ### macOS
+            Make the file executable with `chmod +x ghoti` if needed
+            You may need to allow the app in System Preferences > Security & Privacy
+            
+            ### Windows
+            Run the executable by double-clicking or from Command Prompt


### PR DESCRIPTION
This pull request introduces significant improvements to the CI/CD pipeline and build process for the `ghoti` project. The changes include new GitHub Actions workflows for release automation and package updates, as well as enhancements to the `Makefile` for multi-platform builds and release packaging.

### CI/CD Enhancements

* Added a new GitHub Actions workflow (`.github/workflows/release.yml`) to automate the release process when a new tag is pushed. This workflow builds the project, creates release packages, and publishes them to GitHub Releases with detailed release notes.
* Introduced another GitHub Actions workflow (`.github/workflows/go-pkg-update.yml`) to request updates on `pkg.go.dev` after a successful release. This ensures that the latest version is indexed and available for Go developers.

### Build Process Improvements

* Enhanced the `Makefile` with a new `build-all` target to build the `ghoti` binary for multiple platforms (Linux, macOS, and Windows) and architectures (amd64, arm64, 386).
* Added a `release` target to the `Makefile` for creating release packages. This includes zipping binaries along with the `README.md` file for each platform and architecture.