### PR TITLE
Add slot to error responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,27 @@ In this example, the slot has a UUID stored.
 
 When a client wants to write a value on a slot, they can use the `w` command:
 
-`wHelloWorld`
+`w000HelloWorld`
 
+This will write the value `HelloWorld` on the slot `000`. The value can be any string with a maximum of 36 characters.
 Same as the read command, the server will return the written value:
 
-`vHelloWorld`
+`v000HelloWorld`
 
 If there is any issue with a command, the server will return an error with a code that can be used to identify the issue:
 
-`e009`
+`e000009`
+
+In this case, the error code has 3 parts:
+- `e` indicates is an error response.
+- `000` is the slot number.
+- `009` is the error code.
+
+In the case of commands that are not related to a specifc slot, the slot number will be "xxx". For example, if you want to login, the command to enter the password would be `p` and it won't be related to any slot. The response when the password is empty would be:
+
+`exxx003`
+
+Where `e` indicates is an error response, `xxx` is the slot number and `009` is the error code.:w
 
 To identify the error code, the list of error codes can be found [here](internal/errors/README.md).
 
@@ -66,7 +78,7 @@ In some cases there are messages sent as async events from the server (see broad
 
 Same as the other examples, it would contain the `a` response, then the slot (in this case 234) and the event data (in this case a UUID).
 
-Async events can happen at any time.
+NOTE: Async events can happen at any time.
 
 ### Protocol variants
 

--- a/internal/connection_manager/tcp_manager.go
+++ b/internal/connection_manager/tcp_manager.go
@@ -116,7 +116,7 @@ func (c *TcpManager) handleUserConnection(callback CallbackFn, conn Connection) 
 				slog.String("remote_addr", conn.Id),
 				slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
 			)
-			conn.SendEvent(res.Response())
+			conn.SendEvent(res.Response("xxx"))
 			continue
 		}
 		size -= 1

--- a/internal/connection_manager/telnet_manager.go
+++ b/internal/connection_manager/telnet_manager.go
@@ -101,7 +101,7 @@ func (m *TelnetManager) handleUserConnection(callback CallbackFn, conn Connectio
 				slog.String("remote_addr", conn.Id),
 				slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
 			)
-			conn.SendEvent(res.Response())
+			conn.SendEvent(res.Response("xxx"))
 			continue
 		}
 		conn.Buffer[size-2] = 10

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -30,8 +30,8 @@ func (e ErrorCode) String() string {
 	return e.id
 }
 
-func (e ErrorCode) Response() string {
-	return e.response
+func (e ErrorCode) Response(slot string) string {
+	return fmt.Sprintf("e%s%s", slot, e.response)
 }
 
 func loadValues() map[string]ErrorCode {
@@ -42,7 +42,7 @@ func loadValues() map[string]ErrorCode {
 	for _, v := range matches {
 		id := fmt.Sprint(v[3:6])
 		name := fmt.Sprint(v[8:len(v)])
-		response := fmt.Sprintf("e%s\n", id)
+		response := fmt.Sprintf("%s\n", id)
 
 		e := ErrorCode{name: name, id: id, response: response}
 		m[name] = e

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -15,7 +15,7 @@ func TestError(t *testing.T) {
 		t.Fatalf("Error name was not NOT_LEADER: %s", e.name)
 	}
 
-	if e.response != "e000\n" {
+	if e.response != "000\n" {
 		t.Fatalf("Error response was not e000: %s", e.response)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -50,7 +50,7 @@ func (s *Server) HandleMessage(size int, data []byte, conn *connection_manager.C
 			slog.String("id", conn.Id),
 			slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
 		)
-		return conn.SendEvent(res.Response())
+		return conn.SendEvent(res.Response("xxx"))
 	}
 
 	current_slot := s.slotsArray[msg.Slot]
@@ -68,7 +68,7 @@ func (s *Server) HandleMessage(size int, data []byte, conn *connection_manager.C
 			slog.String("id", conn.Id),
 			slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
 		)
-		return conn.SendEvent(res.Response() + s.cluster.GetLeader())
+		return conn.SendEvent(res.Response("xxx") + s.cluster.GetLeader())
 	}
 
 	if msg.Command == 'u' {
@@ -86,7 +86,7 @@ func (s *Server) HandleMessage(size int, data []byte, conn *connection_manager.C
 			slog.String("id", conn.Id),
 			slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
 		)
-		return conn.SendEvent(res.Response())
+		return conn.SendEvent(res.Response(fmt.Sprintf("%03d", msg.Slot)))
 	}
 
 	if msg.Command == 'w' {
@@ -111,7 +111,7 @@ func processRead(conn *connection_manager.Connection, current_slot slots.Slot, m
 			slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
 		)
 		res := errors.Error("READ_PERMISSION")
-		err := conn.SendEvent(res.Response())
+		err := conn.SendEvent(res.Response(fmt.Sprintf("%03d", msg.Slot)))
 		return err
 	}
 }
@@ -124,7 +124,7 @@ func processWrite(conn *connection_manager.Connection, current_slot slots.Slot, 
 			slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
 		)
 		res := errors.Error("WRITE_PERMISSION")
-		err := conn.SendEvent(res.Response())
+		err := conn.SendEvent(res.Response(fmt.Sprintf("%03d", msg.Slot)))
 		if err != nil {
 			return err
 		}
@@ -139,7 +139,7 @@ func processWrite(conn *connection_manager.Connection, current_slot slots.Slot, 
 			slog.Int("slot", msg.Slot),
 			slog.Any("error", err),
 		)
-		err = conn.SendEvent(res.Response())
+		err = conn.SendEvent(res.Response(fmt.Sprintf("%03d", msg.Slot)))
 		return err
 	} else {
 		slog.Debug("Value written in slot",
@@ -176,7 +176,7 @@ func processUsername(s *Server, conn *connection_manager.Connection, msg Message
 	err := auth.ValidateUsername(msg.Value)
 	if err != nil {
 		res := errors.Error("WRONG_USER")
-		conn.SendEvent(res.Response())
+		conn.SendEvent(res.Response("xxx"))
 		slog.Debug("Invalid user received",
 			slog.String("user", msg.Value),
 			slog.String("id", conn.Id),
@@ -210,7 +210,7 @@ func processPassword(s *Server, conn *connection_manager.Connection, msg Message
 	user, err := auth.GetUser(conn.Username, msg.Value)
 	if err != nil {
 		res := errors.Error("WRONG_PASS")
-		conn.SendEvent(res.Response())
+		conn.SendEvent(res.Response("xxx"))
 		slog.Debug("Invalid password received",
 			slog.String("id", conn.Id),
 			slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
@@ -223,7 +223,7 @@ func processPassword(s *Server, conn *connection_manager.Connection, msg Message
 	} else {
 		if s.usersMap[user.Name].Password != user.Password {
 			res := errors.Error("WRONG_LOGIN")
-			conn.SendEvent(res.Response())
+			conn.SendEvent(res.Response("xxx"))
 			slog.Warn("Invalid login received",
 				slog.String("id", conn.Id),
 				slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -280,7 +280,7 @@ func TestInvalidUsername(t *testing.T) {
 	// Login as pepe/passw0rd
 	response := sendData(t, conn, "upepe!\n")
 
-	if response != "e002\n" {
+	if response != "exxx002\n" {
 		t.Fatalf("Server did not return error")
 	}
 }
@@ -293,7 +293,7 @@ func TestEmptyPassword(t *testing.T) {
 	// Login with empty password
 	response := sendData(t, conn, "p000\n")
 
-	if response != "e003\n" {
+	if response != "exxx003\n" {
 		t.Fatalf("Server did not return error: %s", response)
 	}
 }
@@ -307,7 +307,7 @@ func TestWrongPassword(t *testing.T) {
 	sendData(t, conn, "upepe\n")
 	response := sendData(t, conn, "p12345\n")
 
-	if response != "e004\n" {
+	if response != "exxx004\n" {
 		t.Fatalf("Server did not return error: %s", response)
 	}
 }
@@ -320,14 +320,14 @@ func TestAccessForbidden(t *testing.T) {
 	// Read on Slot 4 that is password protected
 	response := sendData(t, conn, "r004\n")
 
-	if response != "e008\n" {
+	if response != "e004008\n" {
 		t.Fatalf("Server did not return error: %s", response)
 	}
 
 	// Write on Slot 4 that is password protected
 	response_two := sendData(t, conn, "w004Something\n")
 
-	if response_two != "e006\n" {
+	if response_two != "e004006\n" {
 		t.Fatalf("Server did not return error: %s", response)
 	}
 }
@@ -350,7 +350,7 @@ func TestReadOnly(t *testing.T) {
 	// Write on Slot 4 that is password protected
 	response_two := sendData(t, conn, "w004Something\n")
 
-	if response_two != "e006\n" {
+	if response_two != "e004006\n" {
 		t.Fatalf("Server did not return an error")
 	}
 }
@@ -366,7 +366,7 @@ func TestWriteOnly(t *testing.T) {
 	// Read on Slot 4 that is password protected
 	response := sendData(t, conn, "r004\n")
 
-	if response != "e008\n" {
+	if response != "e004008\n" {
 		t.Fatalf("Server did not return an error")
 	}
 


### PR DESCRIPTION
This pull request introduces changes to enhance error handling by including slot-specific information in error responses and updates the associated documentation and tests accordingly. The most notable changes include modifying the error response format, updating the server logic to reflect these changes, and ensuring the tests and documentation are consistent with the new format.

### Error Response Enhancements:
* Updated the `Response` method in `internal/errors/errors.go` to include the slot number in the error response format. This allows error messages to specify the slot they pertain to, using a formatted string like `e<slot><error_code>`.
* Adjusted the error response initialization in `loadValues` to exclude the `e` prefix, as it is now dynamically added in the `Response` method.

### Server Logic Updates:
* Modified multiple server methods in `internal/server/server.go` to pass the slot number (formatted as a three-digit string) to the `Response` method when sending error events. For example, the `processRead`, `processWrite`, and `processUsername` functions now include slot-specific error responses [[1]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23L89-R89) [[2]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23L127-R127) [[3]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23L179-R179).
* Updated connection handling in `internal/connection_manager/tcp_manager.go` and `internal/connection_manager/telnet_manager.go` to use the new `Response` method with a default slot value of `"xxx"` for commands unrelated to specific slots [[1]](diffhunk://#diff-df2358e763337abc2378c32afba6be1c59c62af22cc035519fc13060cd0913d7L119-R119) [[2]](diffhunk://#diff-63c9476dbd79f8dea00c432d57225f34bbaac6bc145422b5d54f8bfa6e4f8f1fL104-R104).

### Documentation Updates:
* Revised the `README.md` to explain the new error response format, including examples and the handling of slot-specific and non-slot-specific commands.
* Added a note to clarify that asynchronous events can occur at any time.

### Test Adjustments:
* Updated tests in `internal/errors/errors_test.go` and `internal/server/server_test.go` to validate the new error response format. For instance, tests now check for responses like `exxx003` or `e004008` instead of the previous format [[1]](diffhunk://#diff-82f0b44034d8824a72705029d4b94c67d75039c240924871052226ad4c17e235L18-R18) [[2]](diffhunk://#diff-37049e37b989d9dc4f0c6df7b68cac427f3bbe573ddb717e066ffdb6a0bd4d92L323-R330).