### PR TITLE
Replace copy of http.Server with reference

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -78,7 +78,6 @@ func (c *RaftCluster) Start() error {
 	if err != nil {
 		return err
 	}
-	defer c.manager.Close()
 
 	return nil
 }


### PR DESCRIPTION
Presently on master, `joinServer.Stop()` does not stop the HTTP server. I proved this by adding a `sync.WaitGroup` to `joinServer` which caused `Stop()` to stall because `Shutdown` was being called on a different copy of the server from the copy on which Start was called.

I found this because my editor highlighted an instance of a copied lock and when this happens it is common to find other issues.

![image](https://github.com/user-attachments/assets/344b1d42-6ed1-46a7-b8e1-7a6f97f9ed40)

The solution is to make the `server` property a `*http.Server` so there is only one.