### PR TITLE
Fix some lint issues

### DIFF
--- a/cmd/run/integration_test.go
+++ b/cmd/run/integration_test.go
@@ -38,7 +38,7 @@ func TestSingleNode(t *testing.T) {
 	}
 
 	reader := bufio.NewReader(conn)
-	response, err := reader.ReadBytes(byte('\n'))
+	response, _ := reader.ReadBytes(byte('\n'))
 	if string(response[0]) == "e" {
 		t.Fatalf("received error response: %v", string(response))
 	}

--- a/internal/cluster/join_server.go
+++ b/internal/cluster/join_server.go
@@ -86,7 +86,7 @@ func (s *joinServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (s *joinServer) handleJoin(w http.ResponseWriter, r *http.Request) {
 	slog.Info("Received request to join cluster")
-	user, pass, ok := r.BasicAuth()
+	user, pass, _ := r.BasicAuth()
 
 	if user != s.user || pass != s.pass {
 		slog.Warn("Request to join with wrong username/password",
@@ -147,7 +147,7 @@ func (s *joinServer) handleRemove(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user, pass, ok := r.BasicAuth()
+	user, pass, _ := r.BasicAuth()
 	if user != s.user || pass != s.pass {
 		slog.Warn("Request to remove with wrong username/password")
 		w.WriteHeader(http.StatusBadRequest)

--- a/internal/cluster/join_server_test.go
+++ b/internal/cluster/join_server_test.go
@@ -40,7 +40,7 @@ func runServer(t *testing.T, config *ClusterConfig, cluster Cluster) MembershipM
 	return s
 }
 
-// More of an integration test
+// More of an integration test.
 func TestJoin(t *testing.T) {
 	mgrAddr := "localhost:5345"
 	config := &ClusterConfig{Node: "node1", User: "my_user", Pass: "my_pass", ManagerType: "join_server", ManagerAddr: mgrAddr, ManagerJoin: "", Bind: "localhost:5555"}

--- a/internal/connection_manager/connection.go
+++ b/internal/connection_manager/connection.go
@@ -86,13 +86,14 @@ func (c *Connection) SendEvent(data string) error {
 	select {
 	case response := <-c.Callback:
 		slog.Debug("Callback received", slog.String("response", response))
-		if response == eventId+" OK" {
+		switch response {
+		case eventId + " OK":
 			return nil
-		} else if response == eventId+" TIMEOUT" {
+		case eventId + " TIMEOUT":
 			return errors.TranscientError{Err: "Timeout waiting for response"}
-		} else if response == eventId+" ERROR" {
+		case eventId + " ERROR":
 			return errors.TranscientError{Err: "Error sending event"}
-		} else {
+		default:
 			return errors.TranscientError{Err: "Unknown response for event " + eventId + ": " + response}
 		}
 	case <-time.After(200 * time.Millisecond):

--- a/internal/connection_manager/tcp_broadcast_test.go
+++ b/internal/connection_manager/tcp_broadcast_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-// This is a mock for net.Conn
+// This is a mock for net.Conn.
 type TestConn struct {
 }
 
@@ -45,7 +45,7 @@ func (c *TestConn) SetWriteDeadline(t time.Time) error {
 	return nil
 }
 
-// This test creates 100 connections to check the broadcast functionality
+// This test creates 100 connections to check the broadcast functionality.
 func TestBroadcast(t *testing.T) {
 	var wg sync.WaitGroup
 

--- a/internal/slots/slots.go
+++ b/internal/slots/slots.go
@@ -104,7 +104,7 @@ func GetSlot(v *viper.Viper, conn connection_manager.ConnectionManager, id strin
 			return nil, fmt.Errorf("Initial value cannot be negative")
 		}
 
-		refreshRate := 1000
+		var refreshRate int
 		if !v.IsSet("refresh_rate") {
 			return nil, fmt.Errorf("refresh_rate must be set for ticker slot")
 		} else {


### PR DESCRIPTION
This pull request primarily focuses on code cleanup and consistency improvements across multiple files. It includes changes to remove unused error variables, improve naming conventions, and refactor conditional logic for better readability and maintainability.

### Error Handling Improvements:
* Removed unused error variables (`ok`) in `BasicAuth` calls within `internal/cluster/join_server.go` to simplify error handling. [[1]](diffhunk://#diff-1b9ddc56b80ec4e6f333754e6ee9db7a9d7a944335733316c5e88a41800a197fL89-R89) [[2]](diffhunk://#diff-1b9ddc56b80ec4e6f333754e6ee9db7a9d7a944335733316c5e88a41800a197fL150-R150)
* Updated error handling in `SendEvent` method in `internal/connection_manager/connection.go` to use a `switch` statement for clearer conditional logic.

### Naming Consistency:
* Refactored variable names in `internal/cluster/integration_test.go` to use camelCase for consistency (`config_one` → `configOne`, `node_one` → `nodeOne`, etc.). [[1]](diffhunk://#diff-23d58ea0d7ecf877d3b156dd3e05ecc0c94f15cd2c80133286244d567105a77dL20-R184) [[2]](diffhunk://#diff-23d58ea0d7ecf877d3b156dd3e05ecc0c94f15cd2c80133286244d567105a77dL233-R262) [[3]](diffhunk://#diff-23d58ea0d7ecf877d3b156dd3e05ecc0c94f15cd2c80133286244d567105a77dL208-R209)

### Code Style Improvements:
* Added missing periods to comments in `internal/connection_manager/tcp_broadcast_test.go` for consistency with code documentation standards. [[1]](diffhunk://#diff-00757256856c8f08feea793c07c4f70371947920e6a4094419ef19d06689fcceL12-R12) [[2]](diffhunk://#diff-00757256856c8f08feea793c07c4f70371947920e6a4094419ef19d06689fcceL48-R48)
* Updated a comment in `internal/cluster/join_server_test.go` for clarity and style.

### Variable Initialization:
* Changed the initialization of `refreshRate` in `internal/slots/slots.go` to explicitly declare it as a `var` for better readability.

### Error Variable Removal:
* Removed unused error variable (`err`) in `TestSingleNode` in `cmd/run/integration_test.go` to streamline the code.