### PR TITLE
Fix Mutex on slots

### DIFF
--- a/internal/slots/atomic.go
+++ b/internal/slots/atomic.go
@@ -13,12 +13,12 @@ import (
 type atomicSlot struct {
 	users map[string]string
 	value int64
-	mu    sync.Mutex
+	mu    sync.RWMutex
 }
 
 func (a *atomicSlot) Read() string {
-	a.mu.Lock()
-	defer a.mu.Unlock()
+	a.mu.RLock()
+	defer a.mu.RUnlock()
 
 	if math.MaxInt64 == a.value {
 		a.value = 0

--- a/internal/slots/atomic_test.go
+++ b/internal/slots/atomic_test.go
@@ -13,7 +13,7 @@ func loadAtomicSlot(t *testing.T) *atomicSlot {
 	slot := &atomicSlot{
 		users: users,
 		value: 0,
-		mu:    sync.Mutex{},
+		mu:    sync.RWMutex{},
 	}
 	return slot
 }
@@ -71,7 +71,7 @@ func TestAtomicSlotPermissions(t *testing.T) {
 	slot := &atomicSlot{
 		users: users,
 		value: 0,
-		mu:    sync.Mutex{},
+		mu:    sync.RWMutex{},
 	}
 
 	readUser, _ := auth.GetUser("read_user", "pass")


### PR DESCRIPTION
Change Mutex type to be RW Mutex to reduce the locking time for sync operations.