### PR TITLE
Add HTTP/SSE protocol for browser-compatible communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,12 @@ NOTE: Async events can happen at any time.
 The core protocol is always the same despite the variant selected, but there are different options to use as a transport layer. The following are the available options:
 - standard: The protocol works as described in the previous section, it is a plain TCP connection that requires messages to be sent in plain text and terminated with a newline character. This is the default option.
 - telnet: This option is the same as the standard option but it allows the use of the telnet protocol to connect to the server. This option is useful when you want to use a telnet client to connect to the server. The main difference is that the messages are terminated with a return of carriage and a newline character, as specified in the standard telnet protocol.
+- http: Exposes the server over HTTP. Slots can be read with `GET /slot/<id>` and written with `POST /slot/<id>`. For **broadcast** slots, a `GET` request opens a persistent [Server-Sent Events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) stream, so the client receives each broadcast event pushed in real time without polling. Which slots are streaming is determined from the configuration at startup, so there is no runtime overhead per request. Authentication uses HTTP Basic Auth.
 
 Example config:
 
 ```yaml
-protocol: telnet
+protocol: http
 ```
 
 ## Configuration 

--- a/README.md
+++ b/README.md
@@ -369,7 +369,6 @@ If there is something really bad happening (like an issue during a deployment), 
 
 This list is not exhaustive, but it is a good starting point to understand what is missing and what is planned for the future.
 Here are some of the things that are planned for the future:
-- Add support for WebSockets.
 - Add metrics and monitoring (Prometheus, OpenTelemetry, etc).
 - Implement missing slots.
 - Add benchmark for the performance of the slots.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ var SupportedLogFormat = map[string]bool{
 var SupportedProtocols = map[string]bool{
 	"standard": true,
 	"telnet":   true,
+	"http":     true,
 }
 
 type LoggingConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,24 +37,26 @@ type LoggingConfig struct {
 }
 
 type Config struct {
-	TCPAddr     string
-	Slots       [1000]slots.Slot
-	Users       map[string]auth.User
-	Cluster     cluster.ClusterConfig
-	Logging     LoggingConfig
-	Metrics     telemetry.Config
-	Connections connectionmanager.ConnectionManager
-	Protocol    string
+	TCPAddr        string
+	Slots          [1000]slots.Slot
+	StreamingSlots map[int]bool
+	Users          map[string]auth.User
+	Cluster        cluster.ClusterConfig
+	Logging        LoggingConfig
+	Metrics        telemetry.Config
+	Connections    connectionmanager.ConnectionManager
+	Protocol       string
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		TCPAddr:  "localhost:9090",
-		Slots:    [1000]slots.Slot{},
-		Users:    make(map[string]auth.User),
-		Cluster:  cluster.ClusterConfig{},
-		Logging:  LoggingConfig{Level: slog.LevelInfo, Format: "text"},
-		Protocol: "standard",
+		TCPAddr:        "localhost:9090",
+		Slots:          [1000]slots.Slot{},
+		StreamingSlots: make(map[int]bool),
+		Users:          make(map[string]auth.User),
+		Cluster:        cluster.ClusterConfig{},
+		Logging:        LoggingConfig{Level: slog.LevelInfo, Format: "text"},
+		Protocol:       "standard",
 	}
 }
 
@@ -168,8 +170,12 @@ func (c *Config) ConfigureSlots() {
 		key := fmt.Sprintf("slot_%03d", i)
 		num := fmt.Sprintf("%03d", i)
 		if viper.IsSet(key) {
-			slot, _ := slots.GetSlot(viper.Sub(key), c.Connections, num)
+			sub := viper.Sub(key)
+			slot, _ := slots.GetSlot(sub, c.Connections, num)
 			c.Slots[i] = slot
+			if sub.GetString("kind") == "broadcast" {
+				c.StreamingSlots[i] = true
+			}
 		}
 	}
 }

--- a/internal/connectionmanager/connection_manager.go
+++ b/internal/connectionmanager/connection_manager.go
@@ -11,14 +11,6 @@ type ConnectionManager interface {
 	Close()
 }
 
-// StreamingSlot is an optional interface that slot types can implement to indicate
-// they support long-lived subscriptions. When an HTTP GET request targets a slot
-// that implements this interface, the HTTP manager opens an SSE stream instead of
-// returning an immediate value.
-type StreamingSlot interface {
-	IsStreaming() bool
-}
-
 func GetConnectionManager(protocol string) ConnectionManager {
 	switch protocol {
 	case "standard":

--- a/internal/connectionmanager/connection_manager.go
+++ b/internal/connectionmanager/connection_manager.go
@@ -17,6 +17,8 @@ func GetConnectionManager(protocol string) ConnectionManager {
 		return NewTCPManager()
 	case "telnet":
 		return NewTelnetManager()
+	case "http":
+		return NewHTTPManager()
 	default:
 		return nil
 	}

--- a/internal/connectionmanager/connection_manager.go
+++ b/internal/connectionmanager/connection_manager.go
@@ -11,6 +11,14 @@ type ConnectionManager interface {
 	Close()
 }
 
+// StreamingSlot is an optional interface that slot types can implement to indicate
+// they support long-lived subscriptions. When an HTTP GET request targets a slot
+// that implements this interface, the HTTP manager opens an SSE stream instead of
+// returning an immediate value.
+type StreamingSlot interface {
+	IsStreaming() bool
+}
+
 func GetConnectionManager(protocol string) ConnectionManager {
 	switch protocol {
 	case "standard":

--- a/internal/connectionmanager/http_manager.go
+++ b/internal/connectionmanager/http_manager.go
@@ -1,0 +1,461 @@
+package connectionmanager
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/dankomiocevic/ghoti/internal/auth"
+	"github.com/dankomiocevic/ghoti/internal/telemetry"
+)
+
+// fakeAddr implements net.Addr for connections that don't have a real TCP socket.
+type fakeAddr struct {
+	network string
+	addr    string
+}
+
+func (f *fakeAddr) Network() string { return f.network }
+func (f *fakeAddr) String() string  { return f.addr }
+
+// chanConn implements net.Conn backed by a channel, used for HTTP request/response handling.
+// Writes from the EventProcessor are captured in writeCh so the HTTP handler can read them.
+type chanConn struct {
+	writeCh    chan []byte
+	closeCh    chan struct{}
+	closeOnce  sync.Once
+	remoteAddr *fakeAddr
+	localAddr  *fakeAddr
+}
+
+func newChanConn(remote string) *chanConn {
+	return &chanConn{
+		writeCh:    make(chan []byte, 16),
+		closeCh:    make(chan struct{}),
+		remoteAddr: &fakeAddr{"tcp", remote},
+		localAddr:  &fakeAddr{"tcp", "0.0.0.0:0"},
+	}
+}
+
+func (c *chanConn) Write(b []byte) (int, error) {
+	select {
+	case <-c.closeCh:
+		return 0, io.EOF
+	default:
+	}
+	buf := make([]byte, len(b))
+	copy(buf, b)
+	select {
+	case c.writeCh <- buf:
+		return len(b), nil
+	case <-c.closeCh:
+		return 0, io.EOF
+	case <-time.After(500 * time.Millisecond):
+		return 0, fmt.Errorf("write timeout")
+	}
+}
+
+func (c *chanConn) Read(b []byte) (int, error)         { return 0, io.EOF }
+func (c *chanConn) Close() error                        { c.closeOnce.Do(func() { close(c.closeCh) }); return nil }
+func (c *chanConn) RemoteAddr() net.Addr                { return c.remoteAddr }
+func (c *chanConn) LocalAddr() net.Addr                 { return c.localAddr }
+func (c *chanConn) SetDeadline(t time.Time) error       { return nil }
+func (c *chanConn) SetReadDeadline(t time.Time) error   { return nil }
+func (c *chanConn) SetWriteDeadline(t time.Time) error  { return nil }
+
+// sseConn implements net.Conn that writes SSE-formatted events to an http.ResponseWriter.
+// Each line of data written to this conn is emitted as an SSE event.
+type sseConn struct {
+	writer     http.ResponseWriter
+	flusher    http.Flusher
+	closeCh    chan struct{}
+	closeOnce  sync.Once
+	remoteAddr *fakeAddr
+	localAddr  *fakeAddr
+}
+
+func newSSEConn(w http.ResponseWriter, flusher http.Flusher, remote string) *sseConn {
+	return &sseConn{
+		writer:     w,
+		flusher:    flusher,
+		closeCh:    make(chan struct{}),
+		remoteAddr: &fakeAddr{"tcp", remote},
+		localAddr:  &fakeAddr{"tcp", "0.0.0.0:0"},
+	}
+}
+
+func (c *sseConn) Write(b []byte) (int, error) {
+	select {
+	case <-c.closeCh:
+		return 0, io.EOF
+	default:
+	}
+	// Each non-empty line is emitted as an SSE event: "data: <line>\n\n"
+	raw := strings.TrimRight(string(b), "\n")
+	for _, line := range strings.Split(raw, "\n") {
+		if line == "" {
+			continue
+		}
+		fmt.Fprintf(c.writer, "data: %s\n\n", line)
+	}
+	c.flusher.Flush()
+	return len(b), nil
+}
+
+func (c *sseConn) Read(b []byte) (int, error)         { return 0, io.EOF }
+func (c *sseConn) Close() error                        { c.closeOnce.Do(func() { close(c.closeCh) }); return nil }
+func (c *sseConn) RemoteAddr() net.Addr                { return c.remoteAddr }
+func (c *sseConn) LocalAddr() net.Addr                 { return c.localAddr }
+func (c *sseConn) SetDeadline(t time.Time) error       { return nil }
+func (c *sseConn) SetReadDeadline(t time.Time) error   { return nil }
+func (c *sseConn) SetWriteDeadline(t time.Time) error  { return nil }
+
+// HTTPManager implements ConnectionManager using HTTP for commands and SSE for broadcasts.
+//
+// HTTP endpoints:
+//   - GET  /{slot}    – read slot (e.g. GET /000)
+//   - POST /{slot}    – write slot; request body is the value (e.g. POST /000 with body "hello")
+//   - GET  /subscribe – SSE stream; receives all broadcast events as SSE data lines
+//
+// Authentication uses HTTP Basic Auth, matched against the users map provided via SetUsers.
+// Anonymous access is allowed when no credentials are sent (slots without user restrictions).
+type HTTPManager struct {
+	lock        sync.RWMutex
+	connections map[string]Connection
+	httpServer  *http.Server
+	wg          sync.WaitGroup
+	quit        chan interface{}
+	callback    CallbackFn
+	users       map[string]auth.User
+}
+
+func NewHTTPManager() *HTTPManager {
+	return &HTTPManager{
+		quit:        make(chan interface{}),
+		connections: make(map[string]Connection),
+		users:       make(map[string]auth.User),
+	}
+}
+
+// SetUsers provides the users map used for HTTP Basic Auth verification.
+// Must be called before ServeConnections if any slots require authentication.
+func (h *HTTPManager) SetUsers(users map[string]auth.User) {
+	h.users = users
+}
+
+func (h *HTTPManager) GetAddr() string {
+	if h.httpServer != nil {
+		return h.httpServer.Addr
+	}
+	return ""
+}
+
+func (h *HTTPManager) StartListening(addr string) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/subscribe", h.handleSSE)
+	mux.HandleFunc("/", h.handleSlot)
+	h.httpServer = &http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+	return nil
+}
+
+func (h *HTTPManager) ServeConnections(callback CallbackFn) error {
+	h.callback = callback
+	err := h.httpServer.ListenAndServe()
+	if err != nil && err != http.ErrServerClosed {
+		return err
+	}
+	return nil
+}
+
+func (h *HTTPManager) Close() {
+	close(h.quit)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if h.httpServer != nil {
+		h.httpServer.Shutdown(ctx) //nolint:errcheck
+	}
+	h.wg.Wait()
+}
+
+func (h *HTTPManager) Delete(id string) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	if _, ok := h.connections[id]; ok {
+		delete(h.connections, id)
+		telemetry.DecrConnectedClients()
+	}
+}
+
+// Broadcast sends data to all registered SSE subscriber connections.
+func (h *HTTPManager) Broadcast(data string) (string, error) {
+	callback := make(chan string, 100)
+	defer close(callback)
+	dataBytes := []byte(data)
+
+	eventID := uuid.NewString()
+	event := Event{
+		id:       eventID,
+		data:     dataBytes,
+		callback: callback,
+		timeout:  time.Now().Add(200 * time.Millisecond),
+	}
+
+	h.lock.RLock()
+	connections := make([]Connection, 0, len(h.connections))
+	for _, conn := range h.connections {
+		connections = append(connections, conn)
+	}
+	h.lock.RUnlock()
+
+	sent := 0
+	received := 0
+	errors := 0
+
+	for _, conn := range connections {
+		select {
+		case conn.Events <- event:
+			sent++
+		default:
+			sent++
+			errors++
+		}
+	}
+
+	timeout := time.Now().Add(200 * time.Millisecond)
+outerLoop:
+	for received+errors < sent {
+		select {
+		case response := <-callback:
+			if response == eventID+" OK" {
+				received++
+			} else {
+				errors++
+			}
+		case <-time.After(time.Until(timeout)):
+			break outerLoop
+		}
+	}
+
+	return fmt.Sprintf("%d/%d/%d", received, sent, errors), nil
+}
+
+// createConnection builds a Connection wrapping the provided net.Conn.
+func (h *HTTPManager) createConnection(nc net.Conn) Connection {
+	return Connection{
+		ID:          uuid.New().String(),
+		Quit:        make(chan interface{}),
+		Events:      make(chan Event, 128),
+		NetworkConn: nc,
+		LoggedUser:  auth.User{},
+		Callback:    make(chan string),
+		Buffer:      make([]byte, 41),
+		Timeout:     200 * time.Millisecond,
+	}
+}
+
+// addSSEConnection registers an SSE connection in the broadcast map.
+func (h *HTTPManager) addSSEConnection(conn Connection) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	h.connections[conn.ID] = conn
+	telemetry.IncrConnectedClients()
+}
+
+// authenticate validates HTTP Basic Auth credentials against the users map.
+// Returns (user, true) on success or when no credentials are provided (anonymous).
+// Returns (_, false) when credentials are present but invalid.
+func (h *HTTPManager) authenticate(r *http.Request) (auth.User, bool) {
+	username, password, hasAuth := r.BasicAuth()
+	if !hasAuth {
+		return auth.User{}, true
+	}
+	user, ok := h.users[username]
+	if !ok || user.Password != password {
+		return auth.User{}, false
+	}
+	return user, true
+}
+
+// handleSlot handles GET /{slot} (read) and POST /{slot} (write) requests.
+func (h *HTTPManager) handleSlot(w http.ResponseWriter, r *http.Request) {
+	if h.callback == nil {
+		http.Error(w, "server not ready", http.StatusServiceUnavailable)
+		return
+	}
+
+	// Parse the 3-digit slot number from the URL path.
+	path := strings.TrimPrefix(r.URL.Path, "/")
+	if len(path) != 3 {
+		http.Error(w, "slot must be a 3-digit number (e.g. GET /000)", http.StatusBadRequest)
+		return
+	}
+
+	user, ok := h.authenticate(r)
+	if !ok {
+		w.Header().Set("WWW-Authenticate", `Basic realm="ghoti"`)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	fconn := newChanConn(r.RemoteAddr)
+	conn := h.createConnection(fconn)
+	conn.LoggedUser = user
+	if user.Name != "" {
+		conn.Username = user.Name
+		conn.IsLogged = true
+	}
+
+	defer conn.Close()
+	go conn.EventProcessor()
+
+	var msgStr string
+	switch r.Method {
+	case http.MethodGet:
+		msgStr = fmt.Sprintf("r%s", path)
+	case http.MethodPost:
+		body, err := io.ReadAll(io.LimitReader(r.Body, 37))
+		if err != nil {
+			http.Error(w, "error reading request body", http.StatusBadRequest)
+			return
+		}
+		value := strings.TrimRight(string(body), "\r\n")
+		if len(value) > 36 {
+			http.Error(w, "value too long (max 36 characters)", http.StatusBadRequest)
+			return
+		}
+		msgStr = fmt.Sprintf("w%s%s", path, value)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	msgBytes := []byte(msgStr + "\n")
+	if err := h.callback(len(msgStr), msgBytes, &conn); err != nil {
+		slog.Debug("HTTP callback returned error",
+			slog.String("path", r.URL.Path),
+			slog.Any("error", err),
+		)
+	}
+
+	select {
+	case data := <-fconn.writeCh:
+		h.writeHTTPResponse(w, string(data))
+	case <-time.After(500 * time.Millisecond):
+		http.Error(w, "timeout waiting for server response", http.StatusGatewayTimeout)
+	}
+}
+
+// writeHTTPResponse translates a ghoti protocol response line into an HTTP response.
+//
+//   v000value  → 200 OK, body: "value"
+//   e000006    → 403 Forbidden  (WRITE_PERMISSION / READ_PERMISSION)
+//   e000005    → 404 Not Found  (MISSING_SLOT)
+//   e000000    → 503            (NOT_LEADER)
+//   e000...    → 400 Bad Request
+func (h *HTTPManager) writeHTTPResponse(w http.ResponseWriter, response string) {
+	response = strings.TrimRight(response, "\n")
+	if len(response) == 0 {
+		http.Error(w, "empty response from server", http.StatusInternalServerError)
+		return
+	}
+
+	switch response[0] {
+	case 'v':
+		value := ""
+		if len(response) >= 4 {
+			value = response[4:]
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, value)
+	case 'e':
+		errCode := ""
+		if len(response) >= 7 {
+			errCode = response[4:7]
+		}
+		switch errCode {
+		case "006", "008": // WRITE_PERMISSION, READ_PERMISSION
+			http.Error(w, "forbidden", http.StatusForbidden)
+		case "005": // MISSING_SLOT
+			http.Error(w, "slot not configured", http.StatusNotFound)
+		case "000": // NOT_LEADER
+			http.Error(w, "not the cluster leader", http.StatusServiceUnavailable)
+		default:
+			http.Error(w, fmt.Sprintf("error: %s", errCode), http.StatusBadRequest)
+		}
+	default:
+		slog.Warn("Unexpected response from server", slog.String("response", response))
+		http.Error(w, "unexpected server response", http.StatusInternalServerError)
+	}
+}
+
+// handleSSE handles GET /subscribe, opening a persistent SSE stream.
+// The client receives all broadcast events as SSE data lines until it disconnects.
+func (h *HTTPManager) handleSSE(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	user, ok := h.authenticate(r)
+	if !ok {
+		w.Header().Set("WWW-Authenticate", `Basic realm="ghoti"`)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	sconn := newSSEConn(w, flusher, r.RemoteAddr)
+	conn := h.createConnection(sconn)
+	conn.LoggedUser = user
+	if user.Name != "" {
+		conn.Username = user.Name
+		conn.IsLogged = true
+	}
+
+	h.addSSEConnection(conn)
+
+	h.wg.Add(1)
+	go conn.EventProcessor()
+
+	slog.Debug("SSE subscriber connected",
+		slog.String("id", conn.ID),
+		slog.String("remote_addr", r.RemoteAddr),
+	)
+
+	// Flush the response headers immediately so the client knows the SSE stream
+	// is open and http.Get (or equivalent) returns on the client side.
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	<-r.Context().Done()
+
+	slog.Debug("SSE subscriber disconnected",
+		slog.String("id", conn.ID),
+		slog.String("remote_addr", r.RemoteAddr),
+	)
+
+	h.Delete(conn.ID)
+	conn.Close()
+	h.wg.Done()
+}

--- a/internal/connectionmanager/http_manager.go
+++ b/internal/connectionmanager/http_manager.go
@@ -17,31 +17,18 @@ import (
 	"github.com/dankomiocevic/ghoti/internal/telemetry"
 )
 
-// fakeAddr implements net.Addr for connections that don't have a real TCP socket.
-type fakeAddr struct {
-	network string
-	addr    string
-}
-
-func (f *fakeAddr) Network() string { return f.network }
-func (f *fakeAddr) String() string  { return f.addr }
-
 // chanConn implements net.Conn backed by a channel, used for HTTP request/response handling.
 // Writes from the EventProcessor are captured in writeCh so the HTTP handler can read them.
 type chanConn struct {
-	writeCh    chan []byte
-	closeCh    chan struct{}
-	closeOnce  sync.Once
-	remoteAddr *fakeAddr
-	localAddr  *fakeAddr
+	writeCh   chan []byte
+	closeCh   chan struct{}
+	closeOnce sync.Once
 }
 
-func newChanConn(remote string) *chanConn {
+func newChanConn() *chanConn {
 	return &chanConn{
-		writeCh:    make(chan []byte, 16),
-		closeCh:    make(chan struct{}),
-		remoteAddr: &fakeAddr{"tcp", remote},
-		localAddr:  &fakeAddr{"tcp", "0.0.0.0:0"},
+		writeCh: make(chan []byte, 16),
+		closeCh: make(chan struct{}),
 	}
 }
 
@@ -63,32 +50,28 @@ func (c *chanConn) Write(b []byte) (int, error) {
 	}
 }
 
-func (c *chanConn) Read(b []byte) (int, error)         { return 0, io.EOF }
-func (c *chanConn) Close() error                        { c.closeOnce.Do(func() { close(c.closeCh) }); return nil }
-func (c *chanConn) RemoteAddr() net.Addr                { return c.remoteAddr }
-func (c *chanConn) LocalAddr() net.Addr                 { return c.localAddr }
-func (c *chanConn) SetDeadline(t time.Time) error       { return nil }
-func (c *chanConn) SetReadDeadline(t time.Time) error   { return nil }
-func (c *chanConn) SetWriteDeadline(t time.Time) error  { return nil }
+func (c *chanConn) Read([]byte) (int, error)         { return 0, io.EOF }
+func (c *chanConn) Close() error                     { c.closeOnce.Do(func() { close(c.closeCh) }); return nil }
+func (c *chanConn) RemoteAddr() net.Addr             { return nil }
+func (c *chanConn) LocalAddr() net.Addr              { return nil }
+func (c *chanConn) SetDeadline(time.Time) error      { return nil }
+func (c *chanConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *chanConn) SetWriteDeadline(time.Time) error { return nil }
 
 // sseConn implements net.Conn that writes SSE-formatted events to an http.ResponseWriter.
 // Each line of data written to this conn is emitted as an SSE event.
 type sseConn struct {
-	writer     http.ResponseWriter
-	flusher    http.Flusher
-	closeCh    chan struct{}
-	closeOnce  sync.Once
-	remoteAddr *fakeAddr
-	localAddr  *fakeAddr
+	writer    http.ResponseWriter
+	flusher   http.Flusher
+	closeCh   chan struct{}
+	closeOnce sync.Once
 }
 
-func newSSEConn(w http.ResponseWriter, flusher http.Flusher, remote string) *sseConn {
+func newSSEConn(w http.ResponseWriter, flusher http.Flusher) *sseConn {
 	return &sseConn{
-		writer:     w,
-		flusher:    flusher,
-		closeCh:    make(chan struct{}),
-		remoteAddr: &fakeAddr{"tcp", remote},
-		localAddr:  &fakeAddr{"tcp", "0.0.0.0:0"},
+		writer:  w,
+		flusher: flusher,
+		closeCh: make(chan struct{}),
 	}
 }
 
@@ -110,13 +93,13 @@ func (c *sseConn) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
-func (c *sseConn) Read(b []byte) (int, error)         { return 0, io.EOF }
-func (c *sseConn) Close() error                        { c.closeOnce.Do(func() { close(c.closeCh) }); return nil }
-func (c *sseConn) RemoteAddr() net.Addr                { return c.remoteAddr }
-func (c *sseConn) LocalAddr() net.Addr                 { return c.localAddr }
-func (c *sseConn) SetDeadline(t time.Time) error       { return nil }
-func (c *sseConn) SetReadDeadline(t time.Time) error   { return nil }
-func (c *sseConn) SetWriteDeadline(t time.Time) error  { return nil }
+func (c *sseConn) Read([]byte) (int, error)         { return 0, io.EOF }
+func (c *sseConn) Close() error                     { c.closeOnce.Do(func() { close(c.closeCh) }); return nil }
+func (c *sseConn) RemoteAddr() net.Addr             { return nil }
+func (c *sseConn) LocalAddr() net.Addr              { return nil }
+func (c *sseConn) SetDeadline(time.Time) error      { return nil }
+func (c *sseConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *sseConn) SetWriteDeadline(time.Time) error { return nil }
 
 // HTTPManager implements ConnectionManager using HTTP for commands and SSE for broadcasts.
 //
@@ -308,7 +291,7 @@ func (h *HTTPManager) handleSlot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fconn := newChanConn(r.RemoteAddr)
+	fconn := newChanConn()
 	conn := h.createConnection(fconn)
 	conn.LoggedUser = user
 	if user.Name != "" {
@@ -322,7 +305,7 @@ func (h *HTTPManager) handleSlot(w http.ResponseWriter, r *http.Request) {
 	var msgStr string
 	switch r.Method {
 	case http.MethodGet:
-		msgStr = fmt.Sprintf("r%s", path)
+		msgStr = "r" + path
 	case http.MethodPost:
 		body, err := io.ReadAll(io.LimitReader(r.Body, 37))
 		if err != nil {
@@ -334,7 +317,7 @@ func (h *HTTPManager) handleSlot(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "value too long (max 36 characters)", http.StatusBadRequest)
 			return
 		}
-		msgStr = fmt.Sprintf("w%s%s", path, value)
+		msgStr = "w" + path + value
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -358,11 +341,11 @@ func (h *HTTPManager) handleSlot(w http.ResponseWriter, r *http.Request) {
 
 // writeHTTPResponse translates a ghoti protocol response line into an HTTP response.
 //
-//   v000value  → 200 OK, body: "value"
-//   e000006    → 403 Forbidden  (WRITE_PERMISSION / READ_PERMISSION)
-//   e000005    → 404 Not Found  (MISSING_SLOT)
-//   e000000    → 503            (NOT_LEADER)
-//   e000...    → 400 Bad Request
+//	v000value  → 200 OK, body: "value"
+//	e000006    → 403 Forbidden  (WRITE_PERMISSION / READ_PERMISSION)
+//	e000005    → 404 Not Found  (MISSING_SLOT)
+//	e000000    → 503            (NOT_LEADER)
+//	e000...    → 400 Bad Request
 func (h *HTTPManager) writeHTTPResponse(w http.ResponseWriter, response string) {
 	response = strings.TrimRight(response, "\n")
 	if len(response) == 0 {
@@ -391,7 +374,7 @@ func (h *HTTPManager) writeHTTPResponse(w http.ResponseWriter, response string) 
 		case "000": // NOT_LEADER
 			http.Error(w, "not the cluster leader", http.StatusServiceUnavailable)
 		default:
-			http.Error(w, fmt.Sprintf("error: %s", errCode), http.StatusBadRequest)
+			http.Error(w, "error: "+errCode, http.StatusBadRequest)
 		}
 	default:
 		slog.Warn("Unexpected response from server", slog.String("response", response))
@@ -425,7 +408,7 @@ func (h *HTTPManager) handleSSE(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 
-	sconn := newSSEConn(w, flusher, r.RemoteAddr)
+	sconn := newSSEConn(w, flusher)
 	conn := h.createConnection(sconn)
 	conn.LoggedUser = user
 	if user.Name != "" {

--- a/internal/connectionmanager/http_manager.go
+++ b/internal/connectionmanager/http_manager.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -104,20 +105,21 @@ func (c *sseConn) SetWriteDeadline(time.Time) error { return nil }
 // HTTPManager implements ConnectionManager using HTTP for commands and SSE for broadcasts.
 //
 // HTTP endpoints:
-//   - GET  /{slot}    – read slot (e.g. GET /000)
-//   - POST /{slot}    – write slot; request body is the value (e.g. POST /000 with body "hello")
-//   - GET  /subscribe – SSE stream; receives all broadcast events as SSE data lines
+//   - GET  /{slot} – read slot value (e.g. GET /000); if the slot is a broadcast slot
+//     the connection is upgraded to an SSE stream that receives future events.
+//   - POST /{slot} – write slot; request body is the value (e.g. POST /000 with body "hello")
 //
 // Authentication uses HTTP Basic Auth, matched against the users map provided via SetUsers.
 // Anonymous access is allowed when no credentials are sent (slots without user restrictions).
 type HTTPManager struct {
-	lock        sync.RWMutex
-	connections map[string]Connection
-	httpServer  *http.Server
-	wg          sync.WaitGroup
-	quit        chan interface{}
-	callback    CallbackFn
-	users       map[string]auth.User
+	lock          sync.RWMutex
+	connections   map[string]Connection
+	httpServer    *http.Server
+	wg            sync.WaitGroup
+	quit          chan interface{}
+	callback      CallbackFn
+	users         map[string]auth.User
+	streamChecker func(int) bool
 }
 
 func NewHTTPManager() *HTTPManager {
@@ -134,6 +136,13 @@ func (h *HTTPManager) SetUsers(users map[string]auth.User) {
 	h.users = users
 }
 
+// SetStreamChecker provides a function that reports whether a slot index is a
+// broadcast (streaming) slot. When set, GET requests on streaming slots open an
+// SSE connection instead of returning an immediate value.
+func (h *HTTPManager) SetStreamChecker(fn func(int) bool) {
+	h.streamChecker = fn
+}
+
 func (h *HTTPManager) GetAddr() string {
 	if h.httpServer != nil {
 		return h.httpServer.Addr
@@ -143,7 +152,6 @@ func (h *HTTPManager) GetAddr() string {
 
 func (h *HTTPManager) StartListening(addr string) error {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/subscribe", h.handleSSE)
 	mux.HandleFunc("/", h.handleSlot)
 	h.httpServer = &http.Server{
 		Addr:    addr,
@@ -270,13 +278,15 @@ func (h *HTTPManager) authenticate(r *http.Request) (auth.User, bool) {
 	return user, true
 }
 
-// handleSlot handles GET /{slot} (read) and POST /{slot} (write) requests.
+// handleSlot handles GET /{slot} and POST /{slot}.
+//
+// For GET on a broadcast slot (as determined by the streamChecker), the connection
+// is upgraded to an SSE stream and kept open until the client disconnects; broadcast
+// events are delivered as SSE data lines.
+//
+// For GET on any other slot, the current value is returned immediately.
+// For POST, the request body (up to 36 bytes) is written to the slot.
 func (h *HTTPManager) handleSlot(w http.ResponseWriter, r *http.Request) {
-	if h.callback == nil {
-		http.Error(w, "server not ready", http.StatusServiceUnavailable)
-		return
-	}
-
 	// Parse the 3-digit slot number from the URL path.
 	path := strings.TrimPrefix(r.URL.Path, "/")
 	if len(path) != 3 {
@@ -288,6 +298,21 @@ func (h *HTTPManager) handleSlot(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		w.Header().Set("WWW-Authenticate", `Basic realm="ghoti"`)
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// For GET requests on a streaming (broadcast) slot, open an SSE stream.
+	if r.Method == http.MethodGet {
+		slotNum, err := strconv.Atoi(path)
+		if err == nil && h.streamChecker != nil && h.streamChecker(slotNum) {
+			h.openBroadcastStream(w, r, user)
+			return
+		}
+	}
+
+	// Regular request/response for GET (non-broadcast) and POST.
+	if h.callback == nil {
+		http.Error(w, "server not ready", http.StatusServiceUnavailable)
 		return
 	}
 
@@ -382,24 +407,13 @@ func (h *HTTPManager) writeHTTPResponse(w http.ResponseWriter, response string) 
 	}
 }
 
-// handleSSE handles GET /subscribe, opening a persistent SSE stream.
-// The client receives all broadcast events as SSE data lines until it disconnects.
-func (h *HTTPManager) handleSSE(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-
+// openBroadcastStream upgrades a GET request on a broadcast slot to a persistent SSE stream.
+// The caller receives all future broadcast events as SSE data lines until it disconnects.
+// No immediate value is returned; the connection stays open waiting for writes to the slot.
+func (h *HTTPManager) openBroadcastStream(w http.ResponseWriter, r *http.Request, user auth.User) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		http.Error(w, "streaming not supported", http.StatusInternalServerError)
-		return
-	}
-
-	user, ok := h.authenticate(r)
-	if !ok {
-		w.Header().Set("WWW-Authenticate", `Basic realm="ghoti"`)
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
 

--- a/internal/connectionmanager/http_manager.go
+++ b/internal/connectionmanager/http_manager.go
@@ -432,18 +432,23 @@ func (h *HTTPManager) openBroadcastStream(w http.ResponseWriter, r *http.Request
 
 	h.addSSEConnection(conn)
 
-	h.wg.Add(1)
-	go conn.EventProcessor()
+	// Flush the response headers before starting the EventProcessor goroutine
+	// so that the initial Flush and the goroutine's Flush calls never race on
+	// the same ResponseWriter.
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
 
 	slog.Debug("SSE subscriber connected",
 		slog.String("id", conn.ID),
 		slog.String("remote_addr", r.RemoteAddr),
 	)
 
-	// Flush the response headers immediately so the client knows the SSE stream
-	// is open and http.Get (or equivalent) returns on the client side.
-	w.WriteHeader(http.StatusOK)
-	flusher.Flush()
+	processorDone := make(chan struct{})
+	h.wg.Add(1)
+	go func() {
+		defer close(processorDone)
+		conn.EventProcessor()
+	}()
 
 	<-r.Context().Done()
 
@@ -454,5 +459,8 @@ func (h *HTTPManager) openBroadcastStream(w http.ResponseWriter, r *http.Request
 
 	h.Delete(conn.ID)
 	conn.Close()
+	// Wait for EventProcessor to finish all writes before returning, so the
+	// HTTP framework's finishRequest does not race with a concurrent Flush.
+	<-processorDone
 	h.wg.Done()
 }

--- a/internal/connectionmanager/http_manager_test.go
+++ b/internal/connectionmanager/http_manager_test.go
@@ -179,22 +179,22 @@ func TestHTTPManagerValueTooLong(t *testing.T) {
 	}
 }
 
-func TestHTTPManagerSSEReceivesBroadcast(t *testing.T) {
-	// Use a real HTTP test server for SSE because httptest.NewRecorder
-	// does not implement http.Flusher.
+func TestHTTPManagerBroadcastSlotGetOpenSSE(t *testing.T) {
+	// GET on a slot whose index the streamChecker reports as streaming should
+	// upgrade to an SSE connection instead of returning an immediate value.
+	// Use a real HTTP test server because httptest.NewRecorder does not implement
+	// http.Flusher.
 	h := buildTestManager(echoCallback)
+	// Treat slot 3 (/003) as a broadcast (streaming) slot.
+	h.SetStreamChecker(func(slot int) bool { return slot == 3 })
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/subscribe" {
-			h.handleSSE(w, r)
-		}
-	}))
+	srv := httptest.NewServer(http.HandlerFunc(h.handleSlot))
 	defer srv.Close()
 
-	// Connect SSE subscriber. http.Get returns once the server flushes the
-	// response headers, which happens after h.addSSEConnection – so by the
-	// time we proceed, the connection is already registered for broadcasts.
-	resp, err := http.Get(srv.URL + "/subscribe")
+	// GET /003 – http.Get returns once the server flushes the response headers,
+	// which happens after addSSEConnection, so the connection is registered for
+	// broadcasts by the time we proceed.
+	resp, err := http.Get(srv.URL + "/003")
 	if err != nil {
 		t.Fatalf("SSE connect failed: %v", err)
 	}
@@ -204,8 +204,8 @@ func TestHTTPManagerSSEReceivesBroadcast(t *testing.T) {
 		t.Fatalf("expected 200 from SSE endpoint, got %d", resp.StatusCode)
 	}
 
-	// Broadcast a message and verify all registered connections receive it.
-	stats, err := h.Broadcast("a000hello\n")
+	// Broadcast a message and verify the SSE subscriber receives it.
+	stats, err := h.Broadcast("a003hello\n")
 	if err != nil {
 		t.Fatalf("Broadcast error: %v", err)
 	}
@@ -232,11 +232,29 @@ func TestHTTPManagerSSEReceivesBroadcast(t *testing.T) {
 
 	select {
 	case got := <-done:
-		if got != "a000hello" {
-			t.Fatalf("expected SSE event 'a000hello', got %q", got)
+		if got != "a003hello" {
+			t.Fatalf("expected SSE event 'a003hello', got %q", got)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for SSE event")
+	}
+}
+
+// TestHTTPManagerNonBroadcastSlotGetReturnsValue verifies that a GET on a slot
+// that the streamChecker does not flag as streaming returns an immediate value,
+// even when a streamChecker is installed.
+func TestHTTPManagerNonBroadcastSlotGetReturnsValue(t *testing.T) {
+	h := buildTestManager(echoCallback)
+	// Only slot 3 is streaming; slot 0 should behave normally.
+	h.SetStreamChecker(func(slot int) bool { return slot == 3 })
+
+	req := httptest.NewRequest(http.MethodGet, "/000", nil)
+	rr := httptest.NewRecorder()
+
+	h.handleSlot(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for regular slot GET, got %d: %s", rr.Code, rr.Body.String())
 	}
 }
 

--- a/internal/connectionmanager/http_manager_test.go
+++ b/internal/connectionmanager/http_manager_test.go
@@ -254,7 +254,7 @@ func TestHTTPManagerBroadcastWithNoSubscribers(t *testing.T) {
 }
 
 func TestChanConnWriteAndRead(t *testing.T) {
-	c := newChanConn("127.0.0.1:1234")
+	c := newChanConn()
 	defer c.Close()
 
 	msg := []byte("hello")
@@ -273,7 +273,7 @@ func TestChanConnWriteAndRead(t *testing.T) {
 }
 
 func TestChanConnCloseReturnsEOF(t *testing.T) {
-	c := newChanConn("127.0.0.1:1234")
+	c := newChanConn()
 	c.Close()
 
 	n, err := c.Write([]byte("data"))
@@ -284,7 +284,7 @@ func TestChanConnCloseReturnsEOF(t *testing.T) {
 
 func TestSSEConnFormatsEvents(t *testing.T) {
 	rr := httptest.NewRecorder()
-	sc := newSSEConn(rr, rr, "127.0.0.1:9999")
+	sc := newSSEConn(rr, rr)
 
 	sc.Write([]byte("a000hello\n")) //nolint:errcheck
 
@@ -296,7 +296,7 @@ func TestSSEConnFormatsEvents(t *testing.T) {
 
 func TestSSEConnFormatsMultipleEvents(t *testing.T) {
 	rr := httptest.NewRecorder()
-	sc := newSSEConn(rr, rr, "127.0.0.1:9999")
+	sc := newSSEConn(rr, rr)
 
 	// Two events batched together (as sendBatchedEvents would produce)
 	sc.Write([]byte("a000hello\n\na001world\n")) //nolint:errcheck

--- a/internal/connectionmanager/http_manager_test.go
+++ b/internal/connectionmanager/http_manager_test.go
@@ -1,0 +1,309 @@
+package connectionmanager
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dankomiocevic/ghoti/internal/auth"
+	"github.com/dankomiocevic/ghoti/internal/errs"
+)
+
+// buildTestManager creates an HTTPManager pre-wired with a callback and users.
+func buildTestManager(callback CallbackFn) *HTTPManager {
+	h := NewHTTPManager()
+	h.SetUsers(map[string]auth.User{
+		"alice": {Name: "alice", Password: "secret"},
+	})
+	h.callback = callback
+	return h
+}
+
+// echoCallback simulates a server that always responds with a value response.
+func echoCallback(size int, data []byte, conn *Connection) error {
+	// parse the command byte and slot
+	msg := string(data[:size])
+	slot := "000"
+	if len(msg) >= 4 {
+		slot = msg[1:4]
+	}
+	var value string
+	if msg[0] == 'w' && len(msg) > 4 {
+		value = msg[4:]
+	}
+	return conn.SendEvent(fmt.Sprintf("v%s%s\n", slot, value))
+}
+
+// errorCallback simulates a server that always returns a READ_PERMISSION error.
+func errorCallback(size int, data []byte, conn *Connection) error {
+	msg := string(data[:size])
+	slot := "000"
+	if len(msg) >= 4 {
+		slot = msg[1:4]
+	}
+	res := errs.Error("READ_PERMISSION")
+	return conn.SendEvent(res.Response(slot))
+}
+
+func TestHTTPManagerRead(t *testing.T) {
+	h := buildTestManager(echoCallback)
+
+	req := httptest.NewRequest(http.MethodGet, "/000", nil)
+	rr := httptest.NewRecorder()
+
+	h.handleSlot(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHTTPManagerWrite(t *testing.T) {
+	h := buildTestManager(echoCallback)
+
+	body := strings.NewReader("hello")
+	req := httptest.NewRequest(http.MethodPost, "/000", body)
+	rr := httptest.NewRecorder()
+
+	h.handleSlot(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if rr.Body.String() != "hello" {
+		t.Fatalf("expected body 'hello', got %q", rr.Body.String())
+	}
+}
+
+func TestHTTPManagerWriteOtherSlot(t *testing.T) {
+	h := buildTestManager(echoCallback)
+
+	body := strings.NewReader("world")
+	req := httptest.NewRequest(http.MethodPost, "/042", body)
+	rr := httptest.NewRecorder()
+
+	h.handleSlot(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if rr.Body.String() != "world" {
+		t.Fatalf("expected body 'world', got %q", rr.Body.String())
+	}
+}
+
+func TestHTTPManagerInvalidSlot(t *testing.T) {
+	h := buildTestManager(echoCallback)
+
+	req := httptest.NewRequest(http.MethodGet, "/invalid", nil)
+	rr := httptest.NewRecorder()
+
+	h.handleSlot(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestHTTPManagerMethodNotAllowed(t *testing.T) {
+	h := buildTestManager(echoCallback)
+
+	req := httptest.NewRequest(http.MethodDelete, "/000", nil)
+	rr := httptest.NewRecorder()
+
+	h.handleSlot(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rr.Code)
+	}
+}
+
+func TestHTTPManagerReadPermissionError(t *testing.T) {
+	h := buildTestManager(errorCallback)
+
+	req := httptest.NewRequest(http.MethodGet, "/000", nil)
+	rr := httptest.NewRecorder()
+
+	h.handleSlot(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rr.Code)
+	}
+}
+
+func TestHTTPManagerBasicAuthValid(t *testing.T) {
+	h := buildTestManager(echoCallback)
+
+	req := httptest.NewRequest(http.MethodGet, "/000", nil)
+	req.SetBasicAuth("alice", "secret")
+	rr := httptest.NewRecorder()
+
+	h.handleSlot(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 with valid auth, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHTTPManagerBasicAuthInvalid(t *testing.T) {
+	h := buildTestManager(echoCallback)
+
+	req := httptest.NewRequest(http.MethodGet, "/000", nil)
+	req.SetBasicAuth("alice", "wrong")
+	rr := httptest.NewRecorder()
+
+	h.handleSlot(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 with bad credentials, got %d", rr.Code)
+	}
+}
+
+func TestHTTPManagerValueTooLong(t *testing.T) {
+	h := buildTestManager(echoCallback)
+
+	longValue := strings.Repeat("x", 37)
+	body := strings.NewReader(longValue)
+	req := httptest.NewRequest(http.MethodPost, "/000", body)
+	rr := httptest.NewRecorder()
+
+	h.handleSlot(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for value too long, got %d", rr.Code)
+	}
+}
+
+func TestHTTPManagerSSEReceivesBroadcast(t *testing.T) {
+	// Use a real HTTP test server for SSE because httptest.NewRecorder
+	// does not implement http.Flusher.
+	h := buildTestManager(echoCallback)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/subscribe" {
+			h.handleSSE(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	// Connect SSE subscriber. http.Get returns once the server flushes the
+	// response headers, which happens after h.addSSEConnection – so by the
+	// time we proceed, the connection is already registered for broadcasts.
+	resp, err := http.Get(srv.URL + "/subscribe")
+	if err != nil {
+		t.Fatalf("SSE connect failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from SSE endpoint, got %d", resp.StatusCode)
+	}
+
+	// Broadcast a message and verify all registered connections receive it.
+	stats, err := h.Broadcast("a000hello\n")
+	if err != nil {
+		t.Fatalf("Broadcast error: %v", err)
+	}
+
+	// stats format is "received/sent/errors"
+	parts := strings.Split(stats, "/")
+	if len(parts) != 3 {
+		t.Fatalf("unexpected stats format: %s", stats)
+	}
+
+	// Read one SSE event from the response body.
+	done := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, "data: ") {
+				done <- strings.TrimPrefix(line, "data: ")
+				return
+			}
+		}
+		done <- ""
+	}()
+
+	select {
+	case got := <-done:
+		if got != "a000hello" {
+			t.Fatalf("expected SSE event 'a000hello', got %q", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for SSE event")
+	}
+}
+
+func TestHTTPManagerBroadcastWithNoSubscribers(t *testing.T) {
+	h := buildTestManager(echoCallback)
+
+	stats, err := h.Broadcast("a000test\n")
+	if err != nil {
+		t.Fatalf("Broadcast error: %v", err)
+	}
+	// With zero subscribers: "0/0/0"
+	if stats != "0/0/0" {
+		t.Fatalf("expected '0/0/0', got %q", stats)
+	}
+}
+
+func TestChanConnWriteAndRead(t *testing.T) {
+	c := newChanConn("127.0.0.1:1234")
+	defer c.Close()
+
+	msg := []byte("hello")
+	go func() {
+		c.Write(msg) //nolint:errcheck
+	}()
+
+	select {
+	case got := <-c.writeCh:
+		if string(got) != "hello" {
+			t.Fatalf("expected 'hello', got %q", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out reading from chanConn")
+	}
+}
+
+func TestChanConnCloseReturnsEOF(t *testing.T) {
+	c := newChanConn("127.0.0.1:1234")
+	c.Close()
+
+	n, err := c.Write([]byte("data"))
+	if err != io.EOF {
+		t.Fatalf("expected EOF after close, got err=%v n=%d", err, n)
+	}
+}
+
+func TestSSEConnFormatsEvents(t *testing.T) {
+	rr := httptest.NewRecorder()
+	sc := newSSEConn(rr, rr, "127.0.0.1:9999")
+
+	sc.Write([]byte("a000hello\n")) //nolint:errcheck
+
+	body := rr.Body.String()
+	if body != "data: a000hello\n\n" {
+		t.Fatalf("unexpected SSE body: %q", body)
+	}
+}
+
+func TestSSEConnFormatsMultipleEvents(t *testing.T) {
+	rr := httptest.NewRecorder()
+	sc := newSSEConn(rr, rr, "127.0.0.1:9999")
+
+	// Two events batched together (as sendBatchedEvents would produce)
+	sc.Write([]byte("a000hello\n\na001world\n")) //nolint:errcheck
+
+	body := rr.Body.String()
+	expected := "data: a000hello\n\ndata: a001world\n\n"
+	if body != expected {
+		t.Fatalf("expected %q, got %q", expected, body)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -36,9 +36,14 @@ func NewServer(config *config.Config, cluster cluster.Cluster) *Server {
 	s.slotsArray = config.Slots
 	s.usersMap = config.Users
 
-	// Provide the users map to the HTTP manager so it can verify Basic Auth credentials.
+	// Provide the users map to the HTTP manager so it can verify Basic Auth credentials,
+	// and a checker so it knows which slots are broadcast (streaming) slots.
 	if httpMgr, ok := s.connections.(*connectionmanager.HTTPManager); ok {
 		httpMgr.SetUsers(s.usersMap)
+		httpMgr.SetStreamChecker(func(slot int) bool {
+			_, ok := s.slotsArray[slot].(connectionmanager.StreamingSlot)
+			return ok
+		})
 	}
 
 	go s.connections.ServeConnections(s.HandleMessage)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -37,12 +37,11 @@ func NewServer(config *config.Config, cluster cluster.Cluster) *Server {
 	s.usersMap = config.Users
 
 	// Provide the users map to the HTTP manager so it can verify Basic Auth credentials,
-	// and a checker so it knows which slots are broadcast (streaming) slots.
+	// and the pre-computed set of streaming (broadcast) slot indices from config.
 	if httpMgr, ok := s.connections.(*connectionmanager.HTTPManager); ok {
 		httpMgr.SetUsers(s.usersMap)
 		httpMgr.SetStreamChecker(func(slot int) bool {
-			_, ok := s.slotsArray[slot].(connectionmanager.StreamingSlot)
-			return ok
+			return config.StreamingSlots[slot]
 		})
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -36,6 +36,11 @@ func NewServer(config *config.Config, cluster cluster.Cluster) *Server {
 	s.slotsArray = config.Slots
 	s.usersMap = config.Users
 
+	// Provide the users map to the HTTP manager so it can verify Basic Auth credentials.
+	if httpMgr, ok := s.connections.(*connectionmanager.HTTPManager); ok {
+		httpMgr.SetUsers(s.usersMap)
+	}
+
 	go s.connections.ServeConnections(s.HandleMessage)
 	return s
 }

--- a/internal/slots/broadcast.go
+++ b/internal/slots/broadcast.go
@@ -33,8 +33,6 @@ func (m *broadcastSlot) Read() string {
 	return m.value
 }
 
-func (m *broadcastSlot) IsStreaming() bool { return true }
-
 func (m *broadcastSlot) CanRead(u *auth.User) bool {
 	if len(m.users) == 0 {
 		return true

--- a/internal/slots/broadcast.go
+++ b/internal/slots/broadcast.go
@@ -33,6 +33,8 @@ func (m *broadcastSlot) Read() string {
 	return m.value
 }
 
+func (m *broadcastSlot) IsStreaming() bool { return true }
+
 func (m *broadcastSlot) CanRead(u *auth.User) bool {
 	if len(m.users) == 0 {
 		return true


### PR DESCRIPTION
Implements a new 'http' protocol option alongside the existing TCP/Telnet
protocols. Commands map to HTTP endpoints and broadcasts are delivered over
Server-Sent Events (SSE):

  GET  /000        → read slot 000  (was: r000)
  POST /000        → write slot 000 (was: w000<value>), body is the value
  GET  /subscribe  → SSE stream for all broadcast events

Key design decisions:
- HTTPManager implements the ConnectionManager interface, making it a
  drop-in alternative to TCPManager/TelnetManager
- Authentication uses HTTP Basic Auth, verified against the configured users
  map (wired in via server.go with a type assertion to SetUsers)
- SSE subscribers are registered in the broadcast connections map so they
  receive events from broadcast slots just like TCP clients do
- Two lightweight net.Conn adapters bridge HTTP to the existing Connection /
  EventProcessor machinery without touching those internals:
    chanConn  – captures writes into a channel for request/response
    sseConn   – formats writes as SSE data lines and flushes immediately
- Successful responses return just the slot value (HTTP 200); error codes
  are translated to appropriate HTTP status codes (403, 404, 503, 400)

To enable, set protocol: http in config.yaml (addr still controls the
listen address).

https://claude.ai/code/session_01MfAbvmTBSSpRZSqM5rXovH