### PR TITLE
Add multicast slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ Same as the other examples, it would contain the `a` response, then the slot (in
 
 NOTE: Async events can happen at any time.
 
+Some slots manage a group of clients that should receive their events, instead of all the connected clients (see multicast slots). To join that group a client can use the `s` (subscribe) command, and to leave it the `d` (deregister) command, both followed by the three digits identifying the slot:
+
+`s005`
+
+The response works the same way as a read, a non-zero value means the client is now part of the group:
+
+`v0051`
+
+`d005`
+
+`v0050`
+
+Sending `s` or `d` to a slot that does not support groups of clients returns an error.
+
 ### Protocol variants
 
 The core protocol is always the same despite the variant selected, but there are different options to use as a transport layer. The following are the available options:
@@ -235,32 +249,53 @@ This means that the message was sent to 5 clients, 3 received it and 2 failed.
 
 Writes will propagate the written value to all other clients. Reads will read the last written value.
 
-### Multicast signal propagation (TBD)
+### Multicast signal propagation
 
-Similar to the Broadcast slot but this slot allows to send a message to a specific group of clients. This type of multicast **requires 2 consecutive slots:**
-- Register/Deregister: This slot allows a client to register or deregister from the multicast. If the client is registered, it will receive the events. To register a client can write a value on this slot, to deregister it can write zero. If a client reads this slot, then a non-zero value means the client is already registered and a zero value means is not.
-- Message: This will send a message the same way as the Broadcast slot but it will only send it to registered clients. Writes will propagate the written value to all other clients. Reads will read the last written value.
+Similar to the Broadcast slot but this slot allows to send a message to a specific group of clients, instead of every connected client.
+
+Unlike the Broadcast slot, a client has to join the group before it can receive events. This is done with the `s` (subscribe) command described in the Protocol section. A client that no longer wants to receive events can leave the group with the `d` (deregister) command. Reading the slot with `s`/`d` returns whether the client is now a member: a non-zero value means it is registered, zero means it is not.
+
+Writing to this slot works the same way as the Broadcast slot, but the message is only sent to the clients that are currently registered:
+
+```
+>s005
+<v0051
+>w005HelloWorld
+<a005HelloWorld
+<v0051/1/0
+```
+
+In this example, the client subscribes to slot `005`, then a message is written to it. The subscribed client receives the async event and the write is acknowledged with `1/1/0`, meaning 1 client received it out of 1 that was sent to, with 0 failures.
+
+If a registered client fails to receive `dereg_tries` consecutive messages (for example because it disconnected without deregistering), it is automatically removed from the group.
+
+Reads (`r`) on this slot return the last message written, same as the Broadcast slot.
 
 |Config          | Description |
 |----------------|-------------|
-| timeout        | Time to wait for a confirmation on the clients that the message was received. |
-| dereg_tries    | Number of messages that are tried on a client until is de-registered. |
+| timeout        | Time in milliseconds to wait for a confirmation on the clients that the message was received. Default: 200 |
+| dereg_tries    | Number of consecutive failed messages tried on a client until is de-registered. Default: 3 |
 
+Example config:
+```yaml
+slot_005:
+  type: multicast
+  timeout: 200
+  dereg_tries: 3
+```
 
 ### Random signal propagation (TBD)
 
 This signal propagation slot works like the Multicast signal propagation explained before but with a major diference, the message is not sent to all registered clients, but only one. It uses a pseudo-random generator to distribute the messages among the clients.
 
-It also **requires 2 slots**:
-- Register/Deregister: This slot allows a client to register or deregister from the multicast. If the client is registered, it will receive the events. To register a client can write a value on this slot, to deregister it can write zero. If a client reads this slot, then a non-zero value means the client is already registered and a zero value means is not.
-- Message: This will send a message the same way as the Broadcast slot but it will only send it to registered clients. Writes will propagate the written value to all other clients. Reads will read the last written value.
+Same as the Multicast slot, clients join and leave the group with the `s` and `d` commands described in the Protocol section.
 
 It has the same configuration as the previous slot:
 
 |Config          | Description |
 |----------------|-------------|
-| timeout        | Time to wait for a confirmation on the clients that the message was received. |
-| dereg_tries    | Number of messages that are tried on a client until is de-registered. |
+| timeout        | Time in milliseconds to wait for a confirmation on the clients that the message was received. |
+| dereg_tries    | Number of consecutive failed messages tried on a client until is de-registered. |
 
 
 ### Ticker (watchdog)

--- a/internal/connectionmanager/connection_manager.go
+++ b/internal/connectionmanager/connection_manager.go
@@ -1,11 +1,17 @@
 package connectionmanager
 
+import (
+	"net"
+	"time"
+)
+
 type CallbackFn func(int, []byte, *Connection) error
 
 type ConnectionManager interface {
 	StartListening(string) error
 	ServeConnections(CallbackFn) error
 	Broadcast(string) (string, error)
+	Multicast(data string, targets []net.Conn, timeout time.Duration) (MulticastResult, error)
 	Delete(string)
 	GetAddr() string
 	Close()

--- a/internal/connectionmanager/http_manager.go
+++ b/internal/connectionmanager/http_manager.go
@@ -241,6 +241,19 @@ outerLoop:
 	return fmt.Sprintf("%d/%d/%d", received, sent, errors), nil
 }
 
+// Multicast sends the data only to the connections listed in targets and
+// waits up to timeout for the confirmations.
+func (h *HTTPManager) Multicast(data string, targets []net.Conn, timeout time.Duration) (MulticastResult, error) {
+	h.lock.RLock()
+	connections := make([]Connection, 0, len(h.connections))
+	for _, conn := range h.connections {
+		connections = append(connections, conn)
+	}
+	h.lock.RUnlock()
+
+	return multicastToConnections(connections, targets, data, timeout), nil
+}
+
 // createConnection builds a Connection wrapping the provided net.Conn.
 func (h *HTTPManager) createConnection(nc net.Conn) Connection {
 	return Connection{

--- a/internal/connectionmanager/multicast.go
+++ b/internal/connectionmanager/multicast.go
@@ -1,0 +1,107 @@
+package connectionmanager
+
+import (
+	"net"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// MulticastResult contains the outcome of a multicast delivery.
+// Failed contains the targets that could not receive the message, either
+// because the delivery failed or because they are not connected anymore.
+type MulticastResult struct {
+	Received int
+	Sent     int
+	Errors   int
+	Failed   []net.Conn
+}
+
+// multicastToConnections sends the data to the connections that are included in
+// the targets list and waits up to the timeout for all the confirmations.
+//
+// Every target gets its own event identifier, this way the response can be
+// matched back to the connection that failed. Targets that are not present in
+// the connections list are counted as failures because the client is gone.
+func multicastToConnections(connections []Connection, targets []net.Conn, data string, timeout time.Duration) MulticastResult {
+	result := MulticastResult{}
+	if len(targets) == 0 {
+		return result
+	}
+
+	pending := make(map[net.Conn]struct{}, len(targets))
+	for _, t := range targets {
+		pending[t] = struct{}{}
+	}
+
+	// The channel is never closed and has room for every response, this way the
+	// event processors can never block sending a response we are not reading.
+	callback := make(chan string, len(targets))
+	dataBytes := []byte(data)
+	deadline := time.Now().Add(timeout)
+	events := make(map[string]net.Conn, len(targets))
+
+	for _, conn := range connections {
+		if _, ok := pending[conn.NetworkConn]; !ok {
+			continue
+		}
+		delete(pending, conn.NetworkConn)
+
+		eventID := uuid.NewString()
+		event := Event{
+			id:       eventID,
+			data:     dataBytes,
+			callback: callback,
+			timeout:  deadline,
+		}
+
+		result.Sent++
+		select {
+		case conn.Events <- event:
+			events[eventID] = conn.NetworkConn
+		default:
+			result.Errors++
+			result.Failed = append(result.Failed, conn.NetworkConn)
+		}
+	}
+
+	// The remaining targets are not connected anymore, they still burn a
+	// delivery attempt so they can be de-registered.
+	for target := range pending {
+		result.Sent++
+		result.Errors++
+		result.Failed = append(result.Failed, target)
+	}
+
+	for len(events) > 0 {
+		select {
+		case response := <-callback:
+			id, status, found := strings.Cut(response, " ")
+			if !found {
+				continue
+			}
+
+			conn, ok := events[id]
+			if !ok {
+				continue
+			}
+			delete(events, id)
+
+			if status == "OK" {
+				result.Received++
+			} else {
+				result.Errors++
+				result.Failed = append(result.Failed, conn)
+			}
+		case <-time.After(time.Until(deadline)):
+			for _, conn := range events {
+				result.Errors++
+				result.Failed = append(result.Failed, conn)
+			}
+			return result
+		}
+	}
+
+	return result
+}

--- a/internal/connectionmanager/multicast_test.go
+++ b/internal/connectionmanager/multicast_test.go
@@ -1,0 +1,215 @@
+package connectionmanager
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// This test creates several connections and multicasts a message only to a
+// subset of them, checking that non-targeted connections receive nothing and
+// that the sender is a fair one.
+func TestMulticastOnlyReachesTargets(t *testing.T) {
+	var wg sync.WaitGroup
+
+	servers := []net.Conn{}
+	clients := []net.Conn{}
+
+	for i := 0; i < 10; i++ {
+		server, client := net.Pipe()
+		servers = append(servers, server)
+		clients = append(clients, client)
+	}
+
+	connections := make(map[string]Connection)
+	for i, server := range servers {
+		id := fmt.Sprintf("%d", i+1)
+		c := &Connection{
+			ID:          id,
+			Quit:        make(chan interface{}),
+			Events:      make(chan Event, 10),
+			NetworkConn: server,
+			Callback:    make(chan string, 10),
+			Buffer:      make([]byte, 1024),
+			Timeout:     200,
+		}
+		connections[id] = *c
+		go c.EventProcessor()
+	}
+
+	manager := TCPManager{
+		connections: connections,
+		quit:        make(chan interface{}),
+		lock:        sync.RWMutex{},
+	}
+
+	targets := []net.Conn{servers[2], servers[5]}
+
+	go func() {
+		output, err := manager.Multicast("Hello World", targets, 500*time.Millisecond)
+		if err != nil {
+			t.Errorf("Error multicasting message: %s", err)
+		}
+
+		if output.Received != 2 || output.Sent != 2 || output.Errors != 0 {
+			t.Errorf("Expected 2/2/0, got %d/%d/%d", output.Received, output.Sent, output.Errors)
+		}
+		if len(output.Failed) != 0 {
+			t.Errorf("Expected no failures, got %v", output.Failed)
+		}
+
+		for _, conn := range servers {
+			conn.Close()
+		}
+	}()
+
+	for i, conn := range clients {
+		targeted := i == 2 || i == 5
+
+		wg.Add(1)
+		go func(conn net.Conn, targeted bool) {
+			defer wg.Done()
+			conn.SetDeadline(time.Now().Add(time.Second))
+			value, _ := io.ReadAll(conn)
+			if targeted {
+				if string(value) != "Hello World" {
+					t.Errorf("Expected 'Hello World', got %q", string(value))
+				}
+			} else {
+				if len(value) != 0 {
+					t.Errorf("Non targeted connection received data: %q", string(value))
+				}
+			}
+		}(conn, targeted)
+	}
+
+	wg.Wait()
+}
+
+// This test checks that a target whose connection fails is reported in Failed.
+func TestMulticastReportsFailedTarget(t *testing.T) {
+	server, client := net.Pipe()
+	client.Close()
+	// Closing the client makes writes to server fail once the pipe is drained,
+	// but net.Pipe needs a reader on the other side to unblock the writer, so
+	// instead we close the server side directly which makes sends fail fast.
+	server.Close()
+
+	failingConn := &TestConn{}
+	okServer, okClient := net.Pipe()
+	defer okClient.Close()
+
+	connections := map[string]Connection{
+		"1": {
+			ID:          "1",
+			Quit:        make(chan interface{}),
+			Events:      make(chan Event, 10),
+			NetworkConn: server,
+			Callback:    make(chan string, 10),
+			Buffer:      make([]byte, 1024),
+			Timeout:     200,
+		},
+		"2": {
+			ID:          "2",
+			Quit:        make(chan interface{}),
+			Events:      make(chan Event, 10),
+			NetworkConn: okServer,
+			Callback:    make(chan string, 10),
+			Buffer:      make([]byte, 1024),
+			Timeout:     200,
+		},
+	}
+
+	for _, c := range connections {
+		go c.EventProcessor()
+	}
+
+	manager := TCPManager{
+		connections: connections,
+		quit:        make(chan interface{}),
+		lock:        sync.RWMutex{},
+	}
+
+	var received string
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		okClient.SetDeadline(time.Now().Add(time.Second))
+		buf := make([]byte, len("Hi"))
+		n, _ := io.ReadFull(okClient, buf)
+		received = string(buf[:n])
+	}()
+
+	output, err := manager.Multicast("Hi", []net.Conn{server, okServer, failingConn}, 500*time.Millisecond)
+
+	okServer.Close()
+	<-done
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if received != "Hi" {
+		t.Fatalf("expected the healthy target to receive the message, got %q", received)
+	}
+
+	if output.Sent != 3 {
+		t.Fatalf("expected 3 sent, got %d", output.Sent)
+	}
+	if output.Errors < 2 {
+		t.Fatalf("expected at least 2 errors (closed conn + unknown conn), got %d", output.Errors)
+	}
+
+	failedSet := make(map[net.Conn]bool)
+	for _, c := range output.Failed {
+		failedSet[c] = true
+	}
+	if !failedSet[server] {
+		t.Errorf("closed connection should be reported as failed")
+	}
+	if !failedSet[failingConn] {
+		t.Errorf("unknown connection should be reported as failed")
+	}
+}
+
+// This test checks that a target which is not part of the manager's known
+// connections is still counted and reported as a failure, so callers can
+// deregister it.
+func TestMulticastUnknownTargetIsFailure(t *testing.T) {
+	manager := TCPManager{
+		connections: make(map[string]Connection),
+		quit:        make(chan interface{}),
+		lock:        sync.RWMutex{},
+	}
+
+	unknown := &TestConn{}
+	output, err := manager.Multicast("Hi", []net.Conn{unknown}, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if output.Sent != 1 || output.Errors != 1 || output.Received != 0 {
+		t.Fatalf("expected 0/1/1, got %d/%d/%d", output.Received, output.Sent, output.Errors)
+	}
+	if len(output.Failed) != 1 || output.Failed[0] != unknown {
+		t.Fatalf("expected the unknown connection to be reported as failed, got %v", output.Failed)
+	}
+}
+
+func TestMulticastWithNoTargetsIsNoop(t *testing.T) {
+	manager := TCPManager{
+		connections: make(map[string]Connection),
+		quit:        make(chan interface{}),
+		lock:        sync.RWMutex{},
+	}
+
+	output, err := manager.Multicast("Hi", nil, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if output.Sent != 0 || output.Errors != 0 || output.Received != 0 || len(output.Failed) != 0 {
+		t.Fatalf("expected an empty result, got %+v", output)
+	}
+}

--- a/internal/connectionmanager/multicast_test.go
+++ b/internal/connectionmanager/multicast_test.go
@@ -213,3 +213,214 @@ func TestMulticastWithNoTargetsIsNoop(t *testing.T) {
 		t.Fatalf("expected an empty result, got %+v", output)
 	}
 }
+
+// TelnetManager.Multicast just delegates to the wrapped TCPManager, but that
+// delegation itself needs coverage: without this test the method is entirely
+// unexercised.
+func TestTelnetManagerMulticastDelegatesToTCPManager(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	connections := map[string]Connection{
+		"1": {
+			ID:          "1",
+			Quit:        make(chan interface{}),
+			Events:      make(chan Event, 10),
+			NetworkConn: server,
+			Callback:    make(chan string, 10),
+			Buffer:      make([]byte, 1024),
+			Timeout:     200,
+		},
+	}
+	for _, c := range connections {
+		go c.EventProcessor()
+	}
+
+	manager := &TelnetManager{
+		tcpManager: &TCPManager{
+			connections: connections,
+			quit:        make(chan interface{}),
+			lock:        sync.RWMutex{},
+		},
+	}
+
+	done := make(chan struct{})
+	var received string
+	go func() {
+		defer close(done)
+		client.SetDeadline(time.Now().Add(time.Second))
+		buf := make([]byte, len("Hi"))
+		n, _ := io.ReadFull(client, buf)
+		received = string(buf[:n])
+	}()
+
+	output, err := manager.Multicast("Hi", []net.Conn{server}, 500*time.Millisecond)
+	<-done
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if received != "Hi" {
+		t.Fatalf("expected the target to receive the message, got %q", received)
+	}
+	if output.Sent != 1 || output.Received != 1 || output.Errors != 0 {
+		t.Fatalf("expected 1/1/0, got %+v", output)
+	}
+}
+
+// HTTPManager.Multicast has its own connection snapshot logic (separate from
+// TCPManager's), so it needs its own direct coverage rather than relying on
+// the TCP-level tests above.
+func TestHTTPManagerMulticastOnlyReachesTargets(t *testing.T) {
+	servers := []net.Conn{}
+	clients := []net.Conn{}
+	connections := make(map[string]Connection)
+
+	for i := 0; i < 3; i++ {
+		server, client := net.Pipe()
+		servers = append(servers, server)
+		clients = append(clients, client)
+		defer server.Close()
+		defer client.Close()
+
+		id := fmt.Sprintf("%d", i+1)
+		c := &Connection{
+			ID:          id,
+			Quit:        make(chan interface{}),
+			Events:      make(chan Event, 10),
+			NetworkConn: server,
+			Callback:    make(chan string, 10),
+			Buffer:      make([]byte, 1024),
+			Timeout:     200,
+		}
+		connections[id] = *c
+		go c.EventProcessor()
+	}
+
+	manager := &HTTPManager{
+		connections: connections,
+		lock:        sync.RWMutex{},
+	}
+
+	target := servers[1]
+
+	done := make(chan struct{})
+	var received string
+	go func() {
+		defer close(done)
+		clients[1].SetDeadline(time.Now().Add(time.Second))
+		buf := make([]byte, len("Hey"))
+		n, _ := io.ReadFull(clients[1], buf)
+		received = string(buf[:n])
+	}()
+
+	output, err := manager.Multicast("Hey", []net.Conn{target}, 500*time.Millisecond)
+	<-done
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if received != "Hey" {
+		t.Fatalf("expected the target to receive the message, got %q", received)
+	}
+	if output.Sent != 1 || output.Received != 1 || output.Errors != 0 {
+		t.Fatalf("expected 1/1/0, got %+v", output)
+	}
+
+	// The non-targeted clients must not receive anything.
+	for _, i := range []int{0, 2} {
+		clients[i].SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+		buf := make([]byte, 32)
+		if _, err := clients[i].Read(buf); err == nil {
+			t.Fatalf("client %d should not have received a multicast message", i)
+		}
+	}
+}
+
+// A target whose event queue is already full must be reported as a failure
+// immediately, rather than blocking the multicast call.
+func TestMulticastFullEventQueueMarksTargetFailed(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	events := make(chan Event, 1)
+	events <- Event{} // fill the buffer so the next send takes the "queue full" path.
+
+	connections := map[string]Connection{
+		"1": {
+			ID:          "1",
+			Quit:        make(chan interface{}),
+			Events:      events,
+			NetworkConn: server,
+			Callback:    make(chan string, 10),
+			Buffer:      make([]byte, 1024),
+			Timeout:     200,
+		},
+	}
+	// Deliberately not starting EventProcessor: we are only checking that a
+	// full Events channel is reported as a failed target.
+
+	manager := TCPManager{
+		connections: connections,
+		quit:        make(chan interface{}),
+		lock:        sync.RWMutex{},
+	}
+
+	output, err := manager.Multicast("Hi", []net.Conn{server}, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if output.Sent != 1 || output.Errors != 1 || output.Received != 0 {
+		t.Fatalf("expected 0/1/1, got %d/%d/%d", output.Received, output.Sent, output.Errors)
+	}
+	if len(output.Failed) != 1 || output.Failed[0] != server {
+		t.Fatalf("expected server to be reported as failed, got %v", output.Failed)
+	}
+}
+
+// A target that accepts the event but never acknowledges it must be reported
+// as failed once the timeout elapses, rather than blocking the call forever.
+func TestMulticastTimeoutMarksPendingTargetFailed(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	connections := map[string]Connection{
+		"1": {
+			ID:          "1",
+			Quit:        make(chan interface{}),
+			Events:      make(chan Event, 10),
+			NetworkConn: server,
+			Callback:    make(chan string, 10),
+			Buffer:      make([]byte, 1024),
+			Timeout:     200,
+		},
+	}
+	// Deliberately not starting EventProcessor: the event is accepted into the
+	// queue but never acknowledged, so the call must time out.
+
+	manager := TCPManager{
+		connections: connections,
+		quit:        make(chan interface{}),
+		lock:        sync.RWMutex{},
+	}
+
+	start := time.Now()
+	output, err := manager.Multicast("Hi", []net.Conn{server}, 50*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("Multicast should return promptly after the deadline, took %s", elapsed)
+	}
+	if output.Sent != 1 || output.Errors != 1 || output.Received != 0 {
+		t.Fatalf("expected 0/1/1, got %d/%d/%d", output.Received, output.Sent, output.Errors)
+	}
+	if len(output.Failed) != 1 || output.Failed[0] != server {
+		t.Fatalf("expected server to be reported as failed after timeout, got %v", output.Failed)
+	}
+}

--- a/internal/connectionmanager/tcp_manager.go
+++ b/internal/connectionmanager/tcp_manager.go
@@ -220,6 +220,17 @@ func (c *TCPManager) Close() {
 	c.wg.Wait()
 }
 
+func (c *TCPManager) Multicast(data string, targets []net.Conn, timeout time.Duration) (MulticastResult, error) {
+	c.lock.RLock()
+	connections := make([]Connection, 0, len(c.connections))
+	for _, conn := range c.connections {
+		connections = append(connections, conn)
+	}
+	c.lock.RUnlock()
+
+	return multicastToConnections(connections, targets, data, timeout), nil
+}
+
 func (c *TCPManager) Broadcast(data string) (string, error) {
 	callback := make(chan string, 100)
 	defer close(callback)

--- a/internal/connectionmanager/telnet_manager.go
+++ b/internal/connectionmanager/telnet_manager.go
@@ -3,6 +3,7 @@ package connectionmanager
 import (
 	"log/slog"
 	"net"
+	"time"
 
 	"github.com/dankomiocevic/ghoti/internal/errs"
 )
@@ -141,4 +142,8 @@ func (m *TelnetManager) Close() {
 
 func (m *TelnetManager) Broadcast(data string) (string, error) {
 	return m.tcpManager.Broadcast(data)
+}
+
+func (m *TelnetManager) Multicast(data string, targets []net.Conn, timeout time.Duration) (MulticastResult, error) {
+	return m.tcpManager.Multicast(data, targets, timeout)
 }

--- a/internal/errs/README.md
+++ b/internal/errs/README.md
@@ -110,3 +110,9 @@ The message that was received does not match the expectations for a valid messag
 The user does not have permission to read in this slot.
 
 The requested slot doesn't have read permissions enabled for the current logged in user. If there is no logged in user, then the slot has not open-read permissions.
+
+## 010: UNSUPPORTED_COMMAND
+
+The command sent is not supported by this slot.
+
+The `s` (subscribe) and `d` (deregister) commands are only supported by slots that manage a group of clients, such as the multicast slot. Sending them to any other kind of slot returns this error.

--- a/internal/server/message.go
+++ b/internal/server/message.go
@@ -20,6 +20,8 @@ var SupportedCommands = map[string]bool{
 	"p": true,
 	"j": true,
 	"q": true,
+	"s": true,
+	"d": true,
 }
 
 func ParseMessage(size int, buf []byte) (Message, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -110,6 +110,14 @@ func (s *Server) HandleMessage(size int, data []byte, conn *connectionmanager.Co
 	if msg.Command == 'r' {
 		return processRead(conn, currentSlot, msg)
 	}
+
+	if msg.Command == 's' {
+		return processRegister(conn, currentSlot, msg)
+	}
+
+	if msg.Command == 'd' {
+		return processDeregister(conn, currentSlot, msg)
+	}
 	return nil
 }
 
@@ -127,6 +135,76 @@ func processRead(conn *connectionmanager.Connection, currentSlot slots.Slot, msg
 	res := errs.Error("READ_PERMISSION")
 	err := conn.SendEvent(res.Response(fmt.Sprintf("%03d", msg.Slot)))
 	return err
+}
+
+func processRegister(conn *connectionmanager.Connection, currentSlot slots.Slot, msg Message) error {
+	if !currentSlot.CanRead(&conn.LoggedUser) {
+		slog.Error("Connection trying to register on slot without permission",
+			slog.Int("slot", msg.Slot),
+			slog.String("id", conn.ID),
+			slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
+		)
+		res := errs.Error("READ_PERMISSION")
+		return conn.SendEvent(res.Response(fmt.Sprintf("%03d", msg.Slot)))
+	}
+
+	groupSlot, ok := currentSlot.(slots.GroupSlot)
+	if !ok {
+		slog.Debug("Connection trying to register on a slot that does not support it",
+			slog.Int("slot", msg.Slot),
+			slog.String("id", conn.ID),
+			slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
+		)
+		res := errs.Error("UNSUPPORTED_COMMAND")
+		return conn.SendEvent(res.Response(fmt.Sprintf("%03d", msg.Slot)))
+	}
+
+	value, err := groupSlot.Register(conn.NetworkConn)
+	if err != nil {
+		res := errs.Error("WRITE_FAILED")
+		slog.Error("Error registering in slot",
+			slog.Int("slot", msg.Slot),
+			slog.Any("error", err),
+		)
+		return conn.SendEvent(res.Response(fmt.Sprintf("%03d", msg.Slot)))
+	}
+
+	return sendSlotData(msg, conn, value)
+}
+
+func processDeregister(conn *connectionmanager.Connection, currentSlot slots.Slot, msg Message) error {
+	if !currentSlot.CanRead(&conn.LoggedUser) {
+		slog.Error("Connection trying to deregister on slot without permission",
+			slog.Int("slot", msg.Slot),
+			slog.String("id", conn.ID),
+			slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
+		)
+		res := errs.Error("READ_PERMISSION")
+		return conn.SendEvent(res.Response(fmt.Sprintf("%03d", msg.Slot)))
+	}
+
+	groupSlot, ok := currentSlot.(slots.GroupSlot)
+	if !ok {
+		slog.Debug("Connection trying to deregister on a slot that does not support it",
+			slog.Int("slot", msg.Slot),
+			slog.String("id", conn.ID),
+			slog.String("remote_addr", conn.NetworkConn.RemoteAddr().String()),
+		)
+		res := errs.Error("UNSUPPORTED_COMMAND")
+		return conn.SendEvent(res.Response(fmt.Sprintf("%03d", msg.Slot)))
+	}
+
+	value, err := groupSlot.Deregister(conn.NetworkConn)
+	if err != nil {
+		res := errs.Error("WRITE_FAILED")
+		slog.Error("Error deregistering in slot",
+			slog.Int("slot", msg.Slot),
+			slog.Any("error", err),
+		)
+		return conn.SendEvent(res.Response(fmt.Sprintf("%03d", msg.Slot)))
+	}
+
+	return sendSlotData(msg, conn, value)
 }
 
 func processWrite(conn *connectionmanager.Connection, currentSlot slots.Slot, msg Message) error {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -526,3 +526,28 @@ func TestMulticastUnsupportedOnOtherSlots(t *testing.T) {
 		t.Fatalf("unexpected response: %s", response)
 	}
 }
+
+// Slot 4 is password protected (see generateConfig). An unauthenticated
+// connection has no read permission on it, so register/deregister must be
+// rejected the same way a plain read would be.
+func TestMulticastRegisterPermissionDenied(t *testing.T) {
+	s, conn := runServer(t)
+	defer s.Stop()
+	defer conn.Close()
+
+	response := sendData(t, conn, "s004\n")
+	if response != "e004008\n" {
+		t.Fatalf("unexpected response: %s", response)
+	}
+}
+
+func TestMulticastDeregisterPermissionDenied(t *testing.T) {
+	s, conn := runServer(t)
+	defer s.Stop()
+	defer conn.Close()
+
+	response := sendData(t, conn, "d004\n")
+	if response != "e004008\n" {
+		t.Fatalf("unexpected response: %s", response)
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -48,6 +48,12 @@ func generateConfig(port string) *config.Config {
 	slotFour, _ := slots.GetSlot(viper.Sub("slot_004"), c.Connections, "004")
 	c.Slots[4] = slotFour
 
+	viper.Set("slot_005.kind", "multicast")
+	viper.Set("slot_005.timeout", 300)
+	viper.Set("slot_005.dereg_tries", 2)
+	slotFive, _ := slots.GetSlot(viper.Sub("slot_005"), c.Connections, "005")
+	c.Slots[5] = slotFive
+
 	viper.Set("users.pepe", "passw0rd")
 	viper.Set("users.bobby", "otherPassw0rd")
 	viper.Set("users.sammy", "samPassw0rd")
@@ -413,5 +419,110 @@ func TestTelnetSupport(t *testing.T) {
 
 	if response != "v000Hello\n" {
 		t.Fatalf("unexpected server response: [%s]", response)
+	}
+}
+
+func TestMulticastSubscribeAndReceiveEvent(t *testing.T) {
+	s, subscriber := runServer(t)
+	defer s.Stop()
+	defer subscriber.Close()
+
+	response := sendData(t, subscriber, "s005\n")
+	if response != "v0051\n" {
+		t.Fatalf("unexpected subscribe response: %s", response)
+	}
+
+	sender, err := net.Dial("tcp", s.connections.GetAddr())
+	if err != nil {
+		t.Fatalf("couldn't connect second client: %v", err)
+	}
+	defer sender.Close()
+
+	asyncCh := make(chan string, 1)
+	go func() {
+		reader := bufio.NewReader(subscriber)
+		data, _ := reader.ReadBytes('\n')
+		asyncCh <- string(data)
+	}()
+
+	writeResponse := sendData(t, sender, "w005HelloWorld\n")
+	if writeResponse != "v0051/1/0\n" {
+		t.Fatalf("unexpected write response: %s", writeResponse)
+	}
+
+	select {
+	case event := <-asyncCh:
+		if event != "a005HelloWorld\n" {
+			t.Fatalf("unexpected async event: %s", event)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for the async event")
+	}
+}
+
+func TestMulticastDoesNotReachNonSubscribedClients(t *testing.T) {
+	s, sender := runServer(t)
+	defer s.Stop()
+	defer sender.Close()
+
+	nonSubscribed, err := net.Dial("tcp", s.connections.GetAddr())
+	if err != nil {
+		t.Fatalf("couldn't connect second client: %v", err)
+	}
+	defer nonSubscribed.Close()
+
+	writeResponse := sendData(t, sender, "w005HelloWorld\n")
+	if writeResponse != "v0050/0/0\n" {
+		t.Fatalf("unexpected write response: %s", writeResponse)
+	}
+
+	nonSubscribed.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	buf := make([]byte, 64)
+	n, readErr := nonSubscribed.Read(buf)
+	if readErr == nil {
+		t.Fatalf("non subscribed client should not receive data, got: %s", string(buf[:n]))
+	}
+}
+
+func TestMulticastDeregister(t *testing.T) {
+	s, subscriber := runServer(t)
+	defer s.Stop()
+	defer subscriber.Close()
+
+	response := sendData(t, subscriber, "s005\n")
+	if response != "v0051\n" {
+		t.Fatalf("unexpected subscribe response: %s", response)
+	}
+
+	response = sendData(t, subscriber, "d005\n")
+	if response != "v0050\n" {
+		t.Fatalf("unexpected deregister response: %s", response)
+	}
+
+	sender, err := net.Dial("tcp", s.connections.GetAddr())
+	if err != nil {
+		t.Fatalf("couldn't connect second client: %v", err)
+	}
+	defer sender.Close()
+
+	writeResponse := sendData(t, sender, "w005HelloWorld\n")
+	if writeResponse != "v0050/0/0\n" {
+		t.Fatalf("unexpected write response: %s", writeResponse)
+	}
+}
+
+func TestMulticastUnsupportedOnOtherSlots(t *testing.T) {
+	s, conn := runServer(t)
+	defer s.Stop()
+	defer conn.Close()
+
+	response := sendData(t, conn, "s000\n")
+	if response != "e000010\n" {
+		t.Fatalf("unexpected response: %s", response)
+	}
+
+	response = sendData(t, conn, "d000\n")
+	if response != "e000010\n" {
+		t.Fatalf("unexpected response: %s", response)
 	}
 }

--- a/internal/slots/broadcast_test.go
+++ b/internal/slots/broadcast_test.go
@@ -2,7 +2,9 @@ package slots
 
 import (
 	"fmt"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/dankomiocevic/ghoti/internal/auth"
 	"github.com/dankomiocevic/ghoti/internal/connectionmanager"
@@ -10,10 +12,15 @@ import (
 
 type MockConnectionManager struct {
 	BroadcastFunc func(message string) (string, error)
+	MulticastFunc func(message string, targets []net.Conn, timeout time.Duration) (connectionmanager.MulticastResult, error)
 }
 
 func (m *MockConnectionManager) Broadcast(message string) (string, error) {
 	return m.BroadcastFunc(message)
+}
+
+func (m *MockConnectionManager) Multicast(message string, targets []net.Conn, timeout time.Duration) (connectionmanager.MulticastResult, error) {
+	return m.MulticastFunc(message, targets, timeout)
 }
 
 func (m *MockConnectionManager) StartListening(string) error {

--- a/internal/slots/multicast.go
+++ b/internal/slots/multicast.go
@@ -1,0 +1,140 @@
+package slots
+
+import (
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dankomiocevic/ghoti/internal/auth"
+	"github.com/dankomiocevic/ghoti/internal/connectionmanager"
+)
+
+type multicastSlot struct {
+	users      map[string]string
+	value      string
+	slotID     string
+	timeout    time.Duration
+	deregTries int
+	members    map[net.Conn]int
+	mu         sync.RWMutex
+	manager    connectionmanager.ConnectionManager
+}
+
+func newMulticastSlot(users map[string]string, conn connectionmanager.ConnectionManager, id string, timeout time.Duration, deregTries int) *multicastSlot {
+	return &multicastSlot{
+		users:      users,
+		value:      "",
+		manager:    conn,
+		slotID:     id,
+		timeout:    timeout,
+		deregTries: deregTries,
+		members:    make(map[net.Conn]int),
+	}
+}
+
+func (m *multicastSlot) Read() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.value
+}
+
+func (m *multicastSlot) CanRead(u *auth.User) bool {
+	if len(m.users) == 0 {
+		return true
+	}
+
+	return m.users[u.Name] == "r" || m.users[u.Name] == "a"
+}
+
+func (m *multicastSlot) CanWrite(u *auth.User) bool {
+	if len(m.users) == 0 {
+		return true
+	}
+
+	return m.users[u.Name] == "w" || m.users[u.Name] == "a"
+}
+
+// Register adds the connection to the group of clients that will receive the
+// multicast messages. It is idempotent: subscribing again resets the failure
+// counter for the client.
+func (m *multicastSlot) Register(from net.Conn) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.members[from] = 0
+	return "1", nil
+}
+
+// Deregister removes the connection from the group. Deregistering a
+// connection that is not registered is a no-op.
+func (m *multicastSlot) Deregister(from net.Conn) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.members, from)
+	return "0", nil
+}
+
+func (m *multicastSlot) Write(data string, from net.Conn) (string, error) {
+	m.mu.Lock()
+	m.value = data
+	targets := make([]net.Conn, 0, len(m.members))
+	for conn := range m.members {
+		targets = append(targets, conn)
+	}
+	m.mu.Unlock()
+
+	if len(targets) == 0 {
+		return "0/0/0", nil
+	}
+
+	result, err := m.manager.Multicast(m.buildEvent(data), targets, m.timeout)
+	if err != nil {
+		return "", err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	failed := make(map[net.Conn]struct{}, len(result.Failed))
+	for _, conn := range result.Failed {
+		failed[conn] = struct{}{}
+	}
+
+	for _, conn := range targets {
+		if _, ok := m.members[conn]; !ok {
+			// Already removed by a concurrent register/deregister.
+			continue
+		}
+
+		if _, ok := failed[conn]; ok {
+			m.members[conn]++
+			if m.members[conn] >= m.deregTries {
+				delete(m.members, conn)
+			}
+			continue
+		}
+
+		m.members[conn] = 0
+	}
+
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(result.Received))
+	sb.WriteString("/")
+	sb.WriteString(strconv.Itoa(result.Sent))
+	sb.WriteString("/")
+	sb.WriteString(strconv.Itoa(result.Errors))
+	return sb.String(), nil
+}
+
+func (m *multicastSlot) buildEvent(data string) string {
+	var sb strings.Builder
+	sb.WriteString("a")
+	sb.WriteString(m.slotID)
+	sb.WriteString(data)
+	sb.WriteString("\n")
+	return sb.String()
+}

--- a/internal/slots/multicast_test.go
+++ b/internal/slots/multicast_test.go
@@ -1,0 +1,242 @@
+package slots
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/dankomiocevic/ghoti/internal/auth"
+	"github.com/dankomiocevic/ghoti/internal/connectionmanager"
+)
+
+// fakeConn is a minimal net.Conn used only as an identity in tests.
+type fakeConn struct {
+	net.Conn
+	name string
+}
+
+func loadMulticastSlot(multicastFn func(message string, targets []net.Conn, timeout time.Duration) (connectionmanager.MulticastResult, error)) *multicastSlot {
+	users := make(map[string]string)
+	manager := &MockConnectionManager{
+		MulticastFunc: multicastFn,
+	}
+	return newMulticastSlot(users, manager, "test_slot", 200*time.Millisecond, 3)
+}
+
+func TestMulticastSlotCanReadWhenUsersEmpty(t *testing.T) {
+	slot := loadMulticastSlot(nil)
+
+	readUser, _ := auth.GetUser("read", "pass")
+	if !slot.CanRead(&readUser) {
+		t.Fatalf("we should be able to read when users map is empty")
+	}
+}
+
+func TestMulticastSlotCanWriteWhenUsersEmpty(t *testing.T) {
+	slot := loadMulticastSlot(nil)
+
+	writeUser, _ := auth.GetUser("write", "pass")
+	if !slot.CanWrite(&writeUser) {
+		t.Fatalf("we should be able to write when users map is empty")
+	}
+}
+
+func TestMulticastSlotPermissions(t *testing.T) {
+	users := map[string]string{
+		"read_user":  "r",
+		"write_user": "w",
+		"all_user":   "a",
+	}
+	slot := newMulticastSlot(users, &MockConnectionManager{}, "test_slot", 200*time.Millisecond, 3)
+
+	readUser, _ := auth.GetUser("read_user", "pass")
+	writeUser, _ := auth.GetUser("write_user", "pass")
+	allUser, _ := auth.GetUser("all_user", "pass")
+
+	if !slot.CanRead(&readUser) {
+		t.Fatalf("Read user should have read permissions")
+	}
+	if slot.CanWrite(&readUser) {
+		t.Fatalf("Read user should not have write permissions")
+	}
+	if !slot.CanWrite(&writeUser) {
+		t.Fatalf("Write user should have write permissions")
+	}
+	if !slot.CanRead(&allUser) {
+		t.Fatalf("All user should have read permissions")
+	}
+	if !slot.CanWrite(&allUser) {
+		t.Fatalf("All user should have write permissions")
+	}
+}
+
+func TestMulticastSlotRegisterAndDeregister(t *testing.T) {
+	slot := loadMulticastSlot(nil)
+	conn := &fakeConn{name: "a"}
+
+	response, err := slot.Register(conn)
+	if err != nil {
+		t.Fatalf("unexpected error registering: %v", err)
+	}
+	if response != "1" {
+		t.Fatalf("expected registration response '1', got %q", response)
+	}
+	if _, ok := slot.members[conn]; !ok {
+		t.Fatalf("connection should be registered")
+	}
+
+	response, err = slot.Deregister(conn)
+	if err != nil {
+		t.Fatalf("unexpected error deregistering: %v", err)
+	}
+	if response != "0" {
+		t.Fatalf("expected deregistration response '0', got %q", response)
+	}
+	if _, ok := slot.members[conn]; ok {
+		t.Fatalf("connection should no longer be registered")
+	}
+}
+
+func TestMulticastSlotDeregisterWhenNotRegistered(t *testing.T) {
+	slot := loadMulticastSlot(nil)
+	conn := &fakeConn{name: "a"}
+
+	response, err := slot.Deregister(conn)
+	if err != nil {
+		t.Fatalf("unexpected error deregistering: %v", err)
+	}
+	if response != "0" {
+		t.Fatalf("expected deregistration response '0', got %q", response)
+	}
+}
+
+func TestMulticastSlotWriteWithNoMembersDoesNotCallManager(t *testing.T) {
+	called := false
+	slot := loadMulticastSlot(func(message string, targets []net.Conn, timeout time.Duration) (connectionmanager.MulticastResult, error) {
+		called = true
+		return connectionmanager.MulticastResult{}, nil
+	})
+
+	response, err := slot.Write("hello", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if response != "0/0/0" {
+		t.Fatalf("expected '0/0/0', got %q", response)
+	}
+	if called {
+		t.Fatalf("manager should not be called when there are no members")
+	}
+	if slot.Read() != "hello" {
+		t.Fatalf("value should still be stored")
+	}
+}
+
+func TestMulticastSlotWriteTargetsOnlyRegisteredMembers(t *testing.T) {
+	registered := &fakeConn{name: "registered"}
+
+	var gotTargets []net.Conn
+	slot := loadMulticastSlot(func(message string, targets []net.Conn, timeout time.Duration) (connectionmanager.MulticastResult, error) {
+		gotTargets = targets
+		if message != "atest_slothello\n" {
+			t.Fatalf("unexpected event payload: %q", message)
+		}
+		return connectionmanager.MulticastResult{Received: 1, Sent: 1, Errors: 0}, nil
+	})
+
+	if _, err := slot.Register(registered); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	response, err := slot.Write("hello", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if response != "1/1/0" {
+		t.Fatalf("expected '1/1/0', got %q", response)
+	}
+	if len(gotTargets) != 1 || gotTargets[0] != registered {
+		t.Fatalf("expected only the registered member as target, got %v", gotTargets)
+	}
+}
+
+func TestMulticastSlotDeregistersAfterRepeatedFailures(t *testing.T) {
+	failing := &fakeConn{name: "failing"}
+
+	slot := loadMulticastSlot(func(message string, targets []net.Conn, timeout time.Duration) (connectionmanager.MulticastResult, error) {
+		return connectionmanager.MulticastResult{Received: 0, Sent: 1, Errors: 1, Failed: targets}, nil
+	})
+
+	if _, err := slot.Register(failing); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, ok := slot.members[failing]; !ok {
+			t.Fatalf("member should still be registered before attempt %d", i+1)
+		}
+		if _, err := slot.Write("hello", nil); err != nil {
+			t.Fatalf("unexpected error on write %d: %v", i, err)
+		}
+	}
+
+	if _, ok := slot.members[failing]; ok {
+		t.Fatalf("member should have been deregistered after %d failures", 3)
+	}
+}
+
+func TestMulticastSlotSuccessResetsFailureCounter(t *testing.T) {
+	conn := &fakeConn{name: "flaky"}
+	shouldFail := true
+
+	slot := loadMulticastSlot(func(message string, targets []net.Conn, timeout time.Duration) (connectionmanager.MulticastResult, error) {
+		if shouldFail {
+			return connectionmanager.MulticastResult{Sent: 1, Errors: 1, Failed: targets}, nil
+		}
+		return connectionmanager.MulticastResult{Sent: 1, Received: 1}, nil
+	})
+
+	if _, err := slot.Register(conn); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Two failures, then a success, then a failure again: the member should
+	// still be registered because the success reset the counter.
+	if _, err := slot.Write("m1", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := slot.Write("m2", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	shouldFail = false
+	if _, err := slot.Write("m3", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	shouldFail = true
+	if _, err := slot.Write("m4", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := slot.members[conn]; !ok {
+		t.Fatalf("member should still be registered, the success should have reset the counter")
+	}
+}
+
+func TestMulticastSlotWriteManagerFailure(t *testing.T) {
+	conn := &fakeConn{name: "a"}
+	slot := loadMulticastSlot(func(message string, targets []net.Conn, timeout time.Duration) (connectionmanager.MulticastResult, error) {
+		return connectionmanager.MulticastResult{}, fmt.Errorf("multicast failed")
+	})
+
+	if _, err := slot.Register(conn); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err := slot.Write("hello", nil)
+	if err == nil {
+		t.Fatalf("Error should be returned when manager multicast fails")
+	}
+}

--- a/internal/slots/multicast_test.go
+++ b/internal/slots/multicast_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/viper"
+
 	"github.com/dankomiocevic/ghoti/internal/auth"
 	"github.com/dankomiocevic/ghoti/internal/connectionmanager"
 )
@@ -225,6 +227,33 @@ func TestMulticastSlotSuccessResetsFailureCounter(t *testing.T) {
 	}
 }
 
+// If a member deregisters while a Write's manager.Multicast call is still in
+// flight, the reconciliation step must not resurrect it into the members map.
+func TestMulticastSlotWriteSkipsConcurrentlyDeregisteredMember(t *testing.T) {
+	conn := &fakeConn{name: "leaving"}
+
+	var slot *multicastSlot
+	slot = loadMulticastSlot(func(message string, targets []net.Conn, timeout time.Duration) (connectionmanager.MulticastResult, error) {
+		// Simulate the client deregistering while the send is still in flight.
+		if _, err := slot.Deregister(conn); err != nil {
+			t.Fatalf("unexpected error deregistering: %v", err)
+		}
+		return connectionmanager.MulticastResult{Sent: 1, Received: 1}, nil
+	})
+
+	if _, err := slot.Register(conn); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := slot.Write("hello", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := slot.members[conn]; ok {
+		t.Fatalf("member should stay deregistered, not be resurrected by reconciliation")
+	}
+}
+
 func TestMulticastSlotWriteManagerFailure(t *testing.T) {
 	conn := &fakeConn{name: "a"}
 	slot := loadMulticastSlot(func(message string, targets []net.Conn, timeout time.Duration) (connectionmanager.MulticastResult, error) {
@@ -238,5 +267,63 @@ func TestMulticastSlotWriteManagerFailure(t *testing.T) {
 	_, err := slot.Write("hello", nil)
 	if err == nil {
 		t.Fatalf("Error should be returned when manager multicast fails")
+	}
+}
+
+func TestMulticastGetSlotDefaults(t *testing.T) {
+	v := viper.New()
+	v.Set("kind", "multicast")
+
+	slot, err := GetSlot(v, nil, "005")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	multicast := slot.(*multicastSlot)
+	if multicast.timeout != 200*time.Millisecond {
+		t.Fatalf("expected default timeout of 200ms, got %s", multicast.timeout)
+	}
+	if multicast.deregTries != 3 {
+		t.Fatalf("expected default dereg_tries of 3, got %d", multicast.deregTries)
+	}
+}
+
+func TestMulticastGetSlotCustomConfig(t *testing.T) {
+	v := viper.New()
+	v.Set("kind", "multicast")
+	v.Set("timeout", 500)
+	v.Set("dereg_tries", 5)
+
+	slot, err := GetSlot(v, nil, "005")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	multicast := slot.(*multicastSlot)
+	if multicast.timeout != 500*time.Millisecond {
+		t.Fatalf("expected timeout of 500ms, got %s", multicast.timeout)
+	}
+	if multicast.deregTries != 5 {
+		t.Fatalf("expected dereg_tries of 5, got %d", multicast.deregTries)
+	}
+}
+
+func TestMulticastGetSlotInvalidTimeout(t *testing.T) {
+	v := viper.New()
+	v.Set("kind", "multicast")
+	v.Set("timeout", 0)
+
+	if _, err := GetSlot(v, nil, "005"); err == nil {
+		t.Fatalf("expected an error for a non-positive timeout")
+	}
+}
+
+func TestMulticastGetSlotInvalidDeregTries(t *testing.T) {
+	v := viper.New()
+	v.Set("kind", "multicast")
+	v.Set("dereg_tries", 0)
+
+	if _, err := GetSlot(v, nil, "005"); err == nil {
+		t.Fatalf("expected an error for a non-positive dereg_tries")
 	}
 }

--- a/internal/slots/slots.go
+++ b/internal/slots/slots.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/spf13/viper"
 
@@ -16,6 +17,14 @@ type Slot interface {
 	Write(string, net.Conn) (string, error)
 	CanRead(*auth.User) bool
 	CanWrite(*auth.User) bool
+}
+
+// GroupSlot is implemented by slots that support clients registering or
+// deregistering to receive messages, such as the multicast slot.
+type GroupSlot interface {
+	Slot
+	Register(net.Conn) (string, error)
+	Deregister(net.Conn) (string, error)
 }
 
 func GetSlot(v *viper.Viper, conn connectionmanager.ConnectionManager, id string) (Slot, error) {
@@ -123,6 +132,26 @@ func GetSlot(v *viper.Viper, conn connectionmanager.ConnectionManager, id string
 
 	if kind == "atomic" {
 		return &atomicSlot{value: 0, users: users}, nil
+	}
+
+	if kind == "multicast" {
+		timeoutMillis := 200
+		if v.IsSet("timeout") {
+			timeoutMillis = v.GetInt("timeout")
+		}
+		if timeoutMillis < 1 {
+			return nil, fmt.Errorf("timeout must be bigger than zero for multicast slot")
+		}
+
+		deregTries := 3
+		if v.IsSet("dereg_tries") {
+			deregTries = v.GetInt("dereg_tries")
+		}
+		if deregTries < 1 {
+			return nil, fmt.Errorf("dereg_tries must be bigger than zero for multicast slot")
+		}
+
+		return newMulticastSlot(users, conn, id, time.Duration(timeoutMillis)*time.Millisecond, deregTries), nil
 	}
 
 	return nil, errors.New("invalid kind of slot")


### PR DESCRIPTION
This change adds the Multicast slot that allows to send messages to specific subscribed clients instead of broadcasting to all.