### PR TITLE
Fix wrong configuration on metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,37 @@ When a slot has no defined list of users, then it will have anonymous access by 
 
 For example, the slot 003 in the configuration can be accessed by anyone, even if is not logged in.
 
+## Metrics
+
+Ghoti can optionally collect lightweight runtime metrics (connected clients, requests per second, average request latency) and write them to rotating files in the [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/). Collection uses lock-free atomic counters, so it adds negligible overhead to request handling, and is disabled by default.
+
+To enable it, add a `metrics:` section to the configuration:
+
+```yaml
+metrics:
+  enabled: true
+  output_dir: /var/log/ghoti/metrics  # directory where metric files are written
+  rotation: daily                     # "daily" (default) or "hourly"
+  retain: 7                           # number of rotation files to keep (default: 7)
+  interval: 10                        # seconds between metric snapshots (default: 10)
+```
+
+|Config      |Description                                                          |
+|------------|----------------------------------------------------------------------|
+|enabled     |Enables metrics collection and writing. Default: false.               |
+|output_dir  |Directory where metric files are written. Required when enabled.     |
+|rotation    |How often a new file is started: `daily` or `hourly`. Default: `daily`.|
+|retain      |Number of rotation files to keep; older files are deleted. Default: 7.|
+|interval    |Seconds between metric snapshots. Default: 10.                        |
+
+Each snapshot exposes the following metrics:
+
+|Metric                                     |Description                                                  |
+|--------------------------------------------|--------------------------------------------------------------|
+|`ghoti_connected_clients`                    |Number of currently connected clients (gauge).                |
+|`ghoti_requests_per_second`                  |Requests processed per second over the last interval (gauge).|
+|`ghoti_request_duration_milliseconds`        |Average request duration in milliseconds over the last interval (gauge).|
+
 ## Cluster configuration (Experimental)
 
 Ghoti clusters are created to increment availability, they are not supposed to propagate information to other nodes in order to increase data persistence. When a cluster node fails, another node will take its place but it will start on a clean state without keeping track of the information stored before.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -211,40 +211,40 @@ var supportedRotations = map[string]bool{
 
 // LoadMetrics reads the optional "metrics:" YAML section and populates c.Metrics.
 // Metrics are disabled by default; they must be explicitly enabled with
-// "telemetry.enabled: true".
+// "metrics.enabled: true".
 func (c *Config) LoadMetrics() error {
 	if !viper.IsSet("metrics") {
 		return nil
 	}
 
-	c.Metrics.Enabled = viper.GetBool("telemetry.enabled")
+	c.Metrics.Enabled = viper.GetBool("metrics.enabled")
 	if !c.Metrics.Enabled {
 		return nil
 	}
 
-	c.Metrics.OutputDir = viper.GetString("telemetry.output_dir")
+	c.Metrics.OutputDir = viper.GetString("metrics.output_dir")
 	if c.Metrics.OutputDir == "" {
-		return fmt.Errorf("telemetry.output_dir is required when metrics is enabled")
+		return fmt.Errorf("metrics.output_dir is required when metrics is enabled")
 	}
 
-	if viper.IsSet("telemetry.rotation") {
-		c.Metrics.Rotation = viper.GetString("telemetry.rotation")
+	if viper.IsSet("metrics.rotation") {
+		c.Metrics.Rotation = viper.GetString("metrics.rotation")
 		if !supportedRotations[c.Metrics.Rotation] {
 			return fmt.Errorf("unsupported metrics rotation %q: must be \"hourly\" or \"daily\"", c.Metrics.Rotation)
 		}
 	}
 
-	if viper.IsSet("telemetry.retain") {
-		c.Metrics.Retain = viper.GetInt("telemetry.retain")
+	if viper.IsSet("metrics.retain") {
+		c.Metrics.Retain = viper.GetInt("metrics.retain")
 		if c.Metrics.Retain < 0 {
-			return fmt.Errorf("telemetry.retain must be >= 0")
+			return fmt.Errorf("metrics.retain must be >= 0")
 		}
 	}
 
-	if viper.IsSet("telemetry.interval") {
-		c.Metrics.Interval = viper.GetInt("telemetry.interval")
+	if viper.IsSet("metrics.interval") {
+		c.Metrics.Interval = viper.GetInt("metrics.interval")
 		if c.Metrics.Interval < 1 {
-			return fmt.Errorf("telemetry.interval must be at least 1 second")
+			return fmt.Errorf("metrics.interval must be at least 1 second")
 		}
 	}
 


### PR DESCRIPTION
There was a naming bug on the configuration for metrics that is fixed in this change.