### PR TITLE
Fix HTTP issue

### DIFF
--- a/internal/connectionmanager/http_manager.go
+++ b/internal/connectionmanager/http_manager.go
@@ -18,18 +18,29 @@ import (
 	"github.com/dankomiocevic/ghoti/internal/telemetry"
 )
 
+// httpRemoteAddr adapts the client address string net/http hands us
+// (http.Request.RemoteAddr) into a net.Addr, so the synthetic connections
+// below never hand back a nil net.Addr: code such as the server's logging
+// calls RemoteAddr().String() unconditionally on every connection type.
+type httpRemoteAddr string
+
+func (a httpRemoteAddr) Network() string { return "tcp" }
+func (a httpRemoteAddr) String() string  { return string(a) }
+
 // chanConn implements net.Conn backed by a channel, used for HTTP request/response handling.
 // Writes from the EventProcessor are captured in writeCh so the HTTP handler can read them.
 type chanConn struct {
-	writeCh   chan []byte
-	closeCh   chan struct{}
-	closeOnce sync.Once
+	writeCh    chan []byte
+	closeCh    chan struct{}
+	closeOnce  sync.Once
+	remoteAddr net.Addr
 }
 
-func newChanConn() *chanConn {
+func newChanConn(remoteAddr string) *chanConn {
 	return &chanConn{
-		writeCh: make(chan []byte, 16),
-		closeCh: make(chan struct{}),
+		writeCh:    make(chan []byte, 16),
+		closeCh:    make(chan struct{}),
+		remoteAddr: httpRemoteAddr(remoteAddr),
 	}
 }
 
@@ -53,7 +64,7 @@ func (c *chanConn) Write(b []byte) (int, error) {
 
 func (c *chanConn) Read([]byte) (int, error)         { return 0, io.EOF }
 func (c *chanConn) Close() error                     { c.closeOnce.Do(func() { close(c.closeCh) }); return nil }
-func (c *chanConn) RemoteAddr() net.Addr             { return nil }
+func (c *chanConn) RemoteAddr() net.Addr             { return c.remoteAddr }
 func (c *chanConn) LocalAddr() net.Addr              { return nil }
 func (c *chanConn) SetDeadline(time.Time) error      { return nil }
 func (c *chanConn) SetReadDeadline(time.Time) error  { return nil }
@@ -62,17 +73,19 @@ func (c *chanConn) SetWriteDeadline(time.Time) error { return nil }
 // sseConn implements net.Conn that writes SSE-formatted events to an http.ResponseWriter.
 // Each line of data written to this conn is emitted as an SSE event.
 type sseConn struct {
-	writer    http.ResponseWriter
-	flusher   http.Flusher
-	closeCh   chan struct{}
-	closeOnce sync.Once
+	writer     http.ResponseWriter
+	flusher    http.Flusher
+	closeCh    chan struct{}
+	closeOnce  sync.Once
+	remoteAddr net.Addr
 }
 
-func newSSEConn(w http.ResponseWriter, flusher http.Flusher) *sseConn {
+func newSSEConn(w http.ResponseWriter, flusher http.Flusher, remoteAddr string) *sseConn {
 	return &sseConn{
-		writer:  w,
-		flusher: flusher,
-		closeCh: make(chan struct{}),
+		writer:     w,
+		flusher:    flusher,
+		closeCh:    make(chan struct{}),
+		remoteAddr: httpRemoteAddr(remoteAddr),
 	}
 }
 
@@ -96,7 +109,7 @@ func (c *sseConn) Write(b []byte) (int, error) {
 
 func (c *sseConn) Read([]byte) (int, error)         { return 0, io.EOF }
 func (c *sseConn) Close() error                     { c.closeOnce.Do(func() { close(c.closeCh) }); return nil }
-func (c *sseConn) RemoteAddr() net.Addr             { return nil }
+func (c *sseConn) RemoteAddr() net.Addr             { return c.remoteAddr }
 func (c *sseConn) LocalAddr() net.Addr              { return nil }
 func (c *sseConn) SetDeadline(time.Time) error      { return nil }
 func (c *sseConn) SetReadDeadline(time.Time) error  { return nil }
@@ -329,7 +342,7 @@ func (h *HTTPManager) handleSlot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fconn := newChanConn()
+	fconn := newChanConn(r.RemoteAddr)
 	conn := h.createConnection(fconn)
 	conn.LoggedUser = user
 	if user.Name != "" {
@@ -435,7 +448,7 @@ func (h *HTTPManager) openBroadcastStream(w http.ResponseWriter, r *http.Request
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 
-	sconn := newSSEConn(w, flusher)
+	sconn := newSSEConn(w, flusher, r.RemoteAddr)
 	conn := h.createConnection(sconn)
 	conn.LoggedUser = user
 	if user.Name != "" {

--- a/internal/connectionmanager/http_manager_test.go
+++ b/internal/connectionmanager/http_manager_test.go
@@ -272,7 +272,7 @@ func TestHTTPManagerBroadcastWithNoSubscribers(t *testing.T) {
 }
 
 func TestChanConnWriteAndRead(t *testing.T) {
-	c := newChanConn()
+	c := newChanConn("192.0.2.1:5555")
 	defer c.Close()
 
 	msg := []byte("hello")
@@ -291,7 +291,7 @@ func TestChanConnWriteAndRead(t *testing.T) {
 }
 
 func TestChanConnCloseReturnsEOF(t *testing.T) {
-	c := newChanConn()
+	c := newChanConn("192.0.2.1:5555")
 	c.Close()
 
 	n, err := c.Write([]byte("data"))
@@ -302,7 +302,7 @@ func TestChanConnCloseReturnsEOF(t *testing.T) {
 
 func TestSSEConnFormatsEvents(t *testing.T) {
 	rr := httptest.NewRecorder()
-	sc := newSSEConn(rr, rr)
+	sc := newSSEConn(rr, rr, "192.0.2.1:5555")
 
 	sc.Write([]byte("a000hello\n")) //nolint:errcheck
 
@@ -314,7 +314,7 @@ func TestSSEConnFormatsEvents(t *testing.T) {
 
 func TestSSEConnFormatsMultipleEvents(t *testing.T) {
 	rr := httptest.NewRecorder()
-	sc := newSSEConn(rr, rr)
+	sc := newSSEConn(rr, rr, "192.0.2.1:5555")
 
 	// Two events batched together (as sendBatchedEvents would produce)
 	sc.Write([]byte("a000hello\n\na001world\n")) //nolint:errcheck

--- a/internal/connectionmanager/http_manager_test.go
+++ b/internal/connectionmanager/http_manager_test.go
@@ -300,6 +300,25 @@ func TestChanConnCloseReturnsEOF(t *testing.T) {
 	}
 }
 
+// TestChanConnRemoteAddr guards against regressing to a nil RemoteAddr():
+// server.go logs conn.NetworkConn.RemoteAddr().String() unconditionally, so a
+// nil net.Addr here panics every HTTP request.
+func TestChanConnRemoteAddr(t *testing.T) {
+	c := newChanConn("203.0.113.5:4242")
+	defer c.Close()
+
+	addr := c.RemoteAddr()
+	if addr == nil {
+		t.Fatal("RemoteAddr() returned nil")
+	}
+	if addr.String() != "203.0.113.5:4242" {
+		t.Fatalf("unexpected RemoteAddr: %s", addr.String())
+	}
+	if addr.Network() != "tcp" {
+		t.Fatalf("unexpected Network: %s", addr.Network())
+	}
+}
+
 func TestSSEConnFormatsEvents(t *testing.T) {
 	rr := httptest.NewRecorder()
 	sc := newSSEConn(rr, rr, "192.0.2.1:5555")
@@ -323,5 +342,25 @@ func TestSSEConnFormatsMultipleEvents(t *testing.T) {
 	expected := "data: a000hello\n\ndata: a001world\n\n"
 	if body != expected {
 		t.Fatalf("expected %q, got %q", expected, body)
+	}
+}
+
+// TestSSEConnRemoteAddr guards against regressing to a nil RemoteAddr() on the
+// SSE connection, the same class of bug as TestChanConnRemoteAddr but on the
+// broadcast-stream path (openBroadcastStream), which is otherwise never
+// exercised by a real server since it never calls HandleMessage.
+func TestSSEConnRemoteAddr(t *testing.T) {
+	rr := httptest.NewRecorder()
+	sc := newSSEConn(rr, rr, "203.0.113.5:4242")
+
+	addr := sc.RemoteAddr()
+	if addr == nil {
+		t.Fatal("RemoteAddr() returned nil")
+	}
+	if addr.String() != "203.0.113.5:4242" {
+		t.Fatalf("unexpected RemoteAddr: %s", addr.String())
+	}
+	if addr.Network() != "tcp" {
+		t.Fatalf("unexpected Network: %s", addr.Network())
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2,8 +2,10 @@ package server
 
 import (
 	"bufio"
+	"io"
 	"math/rand/v2"
 	"net"
+	"net/http"
 	"strconv"
 	"strings"
 	"testing"
@@ -77,6 +79,23 @@ func runServer(t *testing.T) (*Server, net.Conn) {
 	}
 
 	return s, conn
+}
+
+// runHTTPServer starts a real Server wired to the http protocol, exactly as
+// production does, and returns the base URL to send requests to. Unlike
+// buildTestManager in the connectionmanager package, this exercises the real
+// server.HandleMessage callback instead of a stub.
+func runHTTPServer(t *testing.T) (*Server, string) {
+	viper.Set("protocol", "http")
+	t.Cleanup(func() { viper.Set("protocol", "standard") })
+
+	port := "9" + strconv.Itoa(rand.IntN(899)+100)
+	s := NewServer(generateConfig(port), cluster.NewEmptyCluster())
+
+	// wait for the HTTP server to start
+	time.Sleep(time.Duration(100) * time.Millisecond)
+
+	return s, "http://localhost:" + port
 }
 
 func sendData(t *testing.T, conn net.Conn, data string) string {
@@ -176,6 +195,50 @@ func TestMessageNotTerminated(t *testing.T) {
 	response := sendData(t, conn, "r0")
 	if !strings.HasPrefix(response, "e") {
 		t.Fatalf("unexpected server response: %s", response)
+	}
+}
+
+func TestHTTPGetSlotValue(t *testing.T) {
+	s, baseURL := runHTTPServer(t)
+	defer s.Stop()
+
+	resp, err := http.Get(baseURL + "/000")
+	if err != nil {
+		t.Fatalf("GET request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("couldn't read response body: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code: %d, body: %s", resp.StatusCode, body)
+	}
+}
+
+func TestHTTPPostSlotValue(t *testing.T) {
+	s, baseURL := runHTTPServer(t)
+	defer s.Stop()
+
+	resp, err := http.Post(baseURL+"/000", "text/plain", strings.NewReader("Hello"))
+	if err != nil {
+		t.Fatalf("POST request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("couldn't read response body: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code: %d, body: %s", resp.StatusCode, body)
+	}
+
+	if string(body) != "Hello" {
+		t.Fatalf("unexpected response body: %s", body)
 	}
 }
 


### PR DESCRIPTION
The synthetic HTTP connections returned nil for RemoteAddr(), which crashed every request when the server tried to log it. Fixed by having them return the real client address instead.