### PR TITLE
Change atomic counter to use lock instead reader lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ BUILD_DIR ?= $(CURDIR)/dist
 GO_BIN ?= $(shell go env GOPATH)/bin
 GO_PACKAGES := $(shell go list ./... | grep -vE "vendor")
 
+# Defaults for the `test-race` target
+RACE_COUNT ?= 3
+RACE_PACKAGES ?= $(GO_PACKAGES)
+
 # Colors for the printf
 RESET = $(shell tput sgr0)
 COLOR_WHITE = $(shell tput setaf 7)
@@ -67,7 +71,7 @@ lint: $(GO_BIN)/golangci-lint ## Lint Go source files
 #-----------------------------------------------------------------------------------------------------------------------
 # Tests
 #-----------------------------------------------------------------------------------------------------------------------
-.PHONY: test generate-mocks
+.PHONY: test test-race generate-mocks
 
 test: generate-mocks ## Run all tests. To run a specific test, pass the FILTER var. Usage `make test FILTER="TestCheckLogs"`
 	# To skip integration tests, define SHORT. Usage `make test SHORT=1`
@@ -94,6 +98,17 @@ else
 endif
 	@cat coverageunit.tmp.out | grep -v "mock" > coverageunit.out
 	@rm coverageunit.tmp.out
+
+test-race: generate-mocks ## Run tests repeatedly under the race detector. Override RACE_COUNT, RACE_PACKAGES or FILTER. Usage `make test-race RACE_PACKAGES=./internal/slots/`
+	# Repeated runs give the detector more interleavings to observe than the
+	# single pass in `make test`. It only reports races on executed paths, so
+	# a clean run is evidence about coverage, not a proof of safety.
+	${call print, "Running tests under the race detector ($(RACE_COUNT) runs)"}
+	@go test -race \
+			-run "$(FILTER)" \
+			-count=$(RACE_COUNT) \
+			-timeout=10m \
+			$(RACE_PACKAGES)
 
 test-bench: generate-mocks ## Run benchmark tests. See https://pkg.go.dev/cmd/go#hdr-Testing_flags
 	${call print, "Running benchmark tests"}

--- a/internal/slots/atomic.go
+++ b/internal/slots/atomic.go
@@ -17,8 +17,8 @@ type atomicSlot struct {
 }
 
 func (a *atomicSlot) Read() string {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
+	a.mu.Lock()
+	defer a.mu.Unlock()
 
 	if math.MaxInt64 == a.value {
 		a.value = 0

--- a/internal/slots/atomic_test.go
+++ b/internal/slots/atomic_test.go
@@ -2,6 +2,7 @@ package slots
 
 import (
 	"math"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -158,5 +159,83 @@ func TestAtomicSlotWriteNegativeValue(t *testing.T) {
 	_, err := slot.Write("-10", nil)
 	if err == nil {
 		t.Fatalf("Write with negative value should return error")
+	}
+}
+
+func TestAtomicSlotConcurrentReadsAreUnique(t *testing.T) {
+	slot := loadAtomicSlot(t)
+
+	const goroutines = 50
+	const readsPerGoroutine = 200
+	const total = goroutines * readsPerGoroutine
+
+	results := make([]string, total)
+	var wg sync.WaitGroup
+
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < readsPerGoroutine; i++ {
+				results[g*readsPerGoroutine+i] = slot.Read()
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	seen := make(map[string]bool, total)
+	for _, value := range results {
+		if seen[value] {
+			t.Fatalf("Read returned duplicate value %s under concurrency", value)
+		}
+		seen[value] = true
+	}
+
+	if len(seen) != total {
+		t.Fatalf("Expected %d unique values, got %d", total, len(seen))
+	}
+
+	if slot.value != int64(total) {
+		t.Fatalf("Expected final value to be %d, got %d", total, slot.value)
+	}
+}
+
+func TestAtomicSlotConcurrentReadsWrapAtMaxInt64(t *testing.T) {
+	slot := loadAtomicSlot(t)
+	slot.value = math.MaxInt64 - 1
+
+	const goroutines = 10
+	var wg sync.WaitGroup
+	results := make([]string, goroutines)
+
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			results[g] = slot.Read()
+		}(g)
+	}
+	wg.Wait()
+
+	// One read must observe MaxInt64, the next must wrap to 0, and the
+	// remaining reads continue from there.
+	seen := make(map[string]bool, goroutines)
+	for _, value := range results {
+		if seen[value] {
+			t.Fatalf("Read returned duplicate value %s while wrapping", value)
+		}
+		seen[value] = true
+	}
+
+	if !seen[strconv.FormatInt(math.MaxInt64, 10)] {
+		t.Fatalf("Expected one read to return MaxInt64, got %v", results)
+	}
+
+	if !seen["0"] {
+		t.Fatalf("Expected one read to wrap to 0, got %v", results)
+	}
+
+	if slot.value != int64(goroutines)-2 {
+		t.Fatalf("Expected final value to be %d after wrapping, got %d", goroutines-2, slot.value)
 	}
 }


### PR DESCRIPTION
The atomic counter was using a mix of lock and reader lock, that created a race condition that allowed to miss atomic increments.