### PR TITLE
Fix concurrency issues on broadcast and connection close

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -19,7 +19,7 @@ jobs:
           cache-dependency-path: './go.sum'
           check-latest: true
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: latest
           args: -v -c .golangci.yaml

--- a/README.md
+++ b/README.md
@@ -295,8 +295,9 @@ slot_003:
 
 ### Broadcast signal propagation
 
-Anything sent to this slot is propagated as a message to every connected client, including the one that wrote it. Any client connected to Ghoti at this point will receive the event at least once.
-This means that the message could be received more than once.
+Anything sent to this slot is propagated as a message to every connected client, including the one that wrote it. Delivery is at most once: the server makes a single attempt per client and does not retry the ones that fail, so a client that is slow, disconnecting or whose queue is full will miss the event. Like the ephemeral Pub/Sub in Redis or Core NATS, this slot is not a durable queue and gives no delivery guarantee.
+
+The response to the write reports the outcome of the attempt as `received/sent/errors`, so the writer can tell how many clients confirmed the event.
 
 The message is sent as an async event, the receiving client will receive the message at any time.
 The message format is the following:

--- a/internal/connectionmanager/connection.go
+++ b/internal/connectionmanager/connection.go
@@ -2,10 +2,12 @@ package connectionmanager
 
 import (
 	"bufio"
+	"bytes"
 	"io"
 	"log/slog"
 	"net"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -21,6 +23,18 @@ type Event struct {
 	callback chan string
 }
 
+// connState holds the parts of a connection that must be shared between every
+// copy of it. Connection values are copied around (the managers keep them in a
+// map by value and hand copies to broadcasters), so the close lifecycle cannot
+// live in the struct itself.
+//
+// A nil state means "never closed": connections built directly as literals,
+// like the ones in the tests, keep working without a shutdown signal.
+type connState struct {
+	once sync.Once
+	done chan struct{}
+}
+
 type Connection struct {
 	ID          string
 	Quit        chan interface{}
@@ -32,6 +46,68 @@ type Connection struct {
 	Callback    chan string
 	Buffer      []byte
 	Timeout     time.Duration
+
+	state *connState
+}
+
+// NewConnection builds a connection ready to be served by an EventProcessor.
+//
+// The Events channel is never closed: the processor goroutine owns the write
+// side of the network connection and drains whatever is queued when the
+// connection is closed. Producers enqueue with Enqueue, so a broadcast that is
+// holding an old copy of a connection can never send on a closed channel.
+func NewConnection(id string, conn net.Conn, bufferSize int, timeout time.Duration) Connection {
+	return Connection{
+		ID:          id,
+		Quit:        make(chan interface{}),
+		Events:      make(chan Event, 128),
+		NetworkConn: conn,
+		LoggedUser:  auth.User{},
+		Username:    "",
+		IsLogged:    false,
+		// Buffered so a callback that arrives just before SendEvent parks on
+		// the channel is not lost, and late ones never block the processor.
+		Callback: make(chan string, 8),
+		Buffer:   make([]byte, bufferSize),
+		Timeout:  timeout,
+		state:    &connState{done: make(chan struct{})},
+	}
+}
+
+// Done returns a channel that is closed when the connection is closed. It is
+// nil for connections that were not built with NewConnection, which in a
+// select behaves as a channel that is never ready.
+func (c *Connection) Done() <-chan struct{} {
+	if c.state == nil {
+		return nil
+	}
+	return c.state.done
+}
+
+// IsClosed reports whether Close has already been called on this connection.
+func (c *Connection) IsClosed() bool {
+	select {
+	case <-c.Done():
+		return true
+	default:
+		return false
+	}
+}
+
+// Enqueue hands an event to the connection's processor goroutine. It reports
+// whether the event was queued: a closed connection or a full queue is a
+// failed delivery attempt, never a block and never a panic.
+func (c *Connection) Enqueue(event Event) bool {
+	if c.IsClosed() {
+		return false
+	}
+
+	select {
+	case c.Events <- event:
+		return true
+	default:
+		return false
+	}
 }
 
 func (c *Connection) ReceiveMessage() (int, error) {
@@ -75,49 +151,57 @@ func (c *Connection) SendEvent(data string) error {
 		slog.String("id", c.ID),
 		slog.Any("event", event))
 
-	// Send event to the channel and return an error if the channel is full
-	select {
-	case c.Events <- event:
-	default:
+	if !c.Enqueue(event) {
 		return errs.PermanentError{Err: "Could not send event, channel full"}
 	}
 
-	// Wait for the callback to be called
-	select {
-	case response := <-c.Callback:
-		slog.Debug("Callback received", slog.String("response", response))
-		switch response {
-		case eventID + " OK":
-			return nil
-		case eventID + " TIMEOUT":
-			return errs.TranscientError{Err: "Timeout waiting for response"}
-		case eventID + " ERROR":
-			return errs.TranscientError{Err: "Error sending event"}
-		default:
-			return errs.TranscientError{Err: "Unknown response for event " + eventID + ": " + response}
+	// Wait for the callback to be called. Responses belonging to an event we
+	// already gave up on are dropped instead of being reported as the answer
+	// to this one.
+	deadline := time.After(200 * time.Millisecond)
+	for {
+		select {
+		case response := <-c.Callback:
+			slog.Debug("Callback received", slog.String("response", response))
+
+			id, status, _ := strings.Cut(response, " ")
+			if id != eventID {
+				continue
+			}
+
+			switch status {
+			case "OK":
+				return nil
+			case "TIMEOUT":
+				return errs.TranscientError{Err: "Timeout waiting for response"}
+			case "ERROR":
+				return errs.TranscientError{Err: "Error sending event"}
+			default:
+				return errs.TranscientError{Err: "Unknown response for event " + eventID + ": " + response}
+			}
+		case <-deadline:
+			return errs.TranscientError{Err: "Timeout waiting for callback"}
 		}
-	case <-time.After(200 * time.Millisecond):
-		return errs.TranscientError{Err: "Timeout waiting for callback"}
 	}
 }
 
+// EventProcessor owns the write side of the connection: it is the only
+// goroutine that writes to the network connection and the only one that
+// consumes the Events queue. It returns once the connection is closed, after
+// failing every event that is still queued so producers do not have to wait
+// for their deadline.
 func (c *Connection) EventProcessor() {
 	var eventBatch []Event
 	batchSize := 20
 	timer := time.NewTimer(0) // Start with a zero timer
 	timer.Stop()              // Stop it immediately
+	defer timer.Stop()
+
+	done := c.Done()
 
 	for {
 		select {
-		case event, ok := <-c.Events:
-			if !ok {
-				// Channel closed, send any remaining events
-				if len(eventBatch) > 0 {
-					c.sendBatchedEvents(eventBatch)
-				}
-				return
-			}
-
+		case event := <-c.Events:
 			eventBatch = append(eventBatch, event)
 
 			// If we have enough events, send immediately
@@ -143,6 +227,27 @@ func (c *Connection) EventProcessor() {
 				c.sendBatchedEvents(eventBatch)
 				eventBatch = eventBatch[:0] // Clear the batch
 			}
+
+		case <-done:
+			c.drain(eventBatch)
+			return
+		}
+	}
+}
+
+// drain answers every event that will never reach the network because the
+// connection is gone.
+func (c *Connection) drain(pending []Event) {
+	for _, event := range pending {
+		respond(event, "ERROR")
+	}
+
+	for {
+		select {
+		case event := <-c.Events:
+			respond(event, "ERROR")
+		default:
+			return
 		}
 	}
 }
@@ -152,60 +257,99 @@ func (c *Connection) sendBatchedEvents(events []Event) {
 		return
 	}
 
-	// Merge events into a single message
-	var sb strings.Builder
-	validEvents := 0
-	for i, event := range events {
+	// Merge the events that are still in time into a single message. The ones
+	// that already expired are answered here and are not written out.
+	//
+	// The batch is filtered in place: the events that are kept are written back
+	// over the ones that were dropped, so the write index never runs ahead of
+	// the read index and no second slice is needed.
+	var buf bytes.Buffer
+	valid := events[:0]
+	for _, event := range events {
 		if time.Now().After(event.timeout) {
-			// Handle timeout events immediately
-			var b strings.Builder
-			b.Grow(40 + 8)
-			b.WriteString(event.id)
-			b.WriteString(" TIMEOUT")
-			event.callback <- b.String()
+			respond(event, "TIMEOUT")
 			continue
 		}
 
-		if i > 0 {
-			sb.WriteString("\n")
+		if len(valid) > 0 {
+			buf.WriteString("\n")
 		}
-		sb.Write(event.data)
-		validEvents++
+		buf.Write(event.data)
+		valid = append(valid, event)
 	}
 
 	// If no valid events to send, return early
-	if validEvents == 0 {
+	if len(valid) == 0 {
 		return
 	}
 
 	// Send the batched data to the network
-	batchedData := sb.String()
 	c.NetworkConn.SetWriteDeadline(time.Now().Add(200 * time.Millisecond))
-	_, err := c.NetworkConn.Write([]byte(batchedData))
+	err := writeFull(c.NetworkConn, buf.Bytes())
 
 	slog.Debug("Sending batched events",
 		slog.String("id", c.ID),
 		slog.Int("event_count", len(events)),
-		slog.Int("total_size", len(batchedData)))
+		slog.Int("total_size", buf.Len()))
 
 	// Handle each event's callback individually
-	for _, event := range events {
-		var b strings.Builder
-		b.Grow(40 + 8)
-		b.WriteString(event.id)
+	status := "OK"
+	if err != nil {
+		status = "ERROR"
+	}
 
-		if err != nil {
-			b.WriteString(" ERROR")
-			event.callback <- b.String()
-			continue
-		}
-
-		b.WriteString(" OK")
-		event.callback <- b.String()
+	for _, event := range valid {
+		respond(event, status)
 	}
 }
 
+// writeFull writes the whole buffer, retrying while the connection keeps
+// making progress. net.Conn.Write can report a partial write, on a deadline
+// for example, so the returned count cannot be ignored: a short write is a
+// truncated event, not a delivered one.
+func writeFull(conn net.Conn, data []byte) error {
+	for written := 0; written < len(data); {
+		n, err := conn.Write(data[written:])
+		if n > 0 {
+			written += n
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if n <= 0 {
+			return io.ErrShortWrite
+		}
+	}
+
+	return nil
+}
+
+// respond delivers the outcome of an event to whoever asked for it without
+// ever blocking. Callback channels are sized to hold every response their
+// owner asked for, so a full channel means the owner already gave up on the
+// event and the processor must not wedge on it.
+func respond(event Event, status string) {
+	var b strings.Builder
+	b.Grow(len(event.id) + len(status) + 1)
+	b.WriteString(event.id)
+	b.WriteString(" ")
+	b.WriteString(status)
+
+	select {
+	case event.callback <- b.String():
+	default:
+	}
+}
+
+// Close signals the processor goroutine to stop and closes the network
+// connection. It is safe to call more than once and never closes the Events
+// channel, so producers holding a copy of the connection cannot panic.
 func (c *Connection) Close() error {
-	close(c.Events)
+	if c.state != nil {
+		c.state.once.Do(func() { close(c.state.done) })
+	}
+
 	return c.NetworkConn.Close()
 }

--- a/internal/connectionmanager/connection.go
+++ b/internal/connectionmanager/connection.go
@@ -304,7 +304,7 @@ func (c *Connection) sendBatchedEvents(events []Event) {
 }
 
 // writeFull writes the whole buffer, retrying while the connection keeps
-// making progress. net.Conn.Write can report a partial write, on a deadline
+// making progress. Then, net.Conn.Write can report a partial write, on a deadline
 // for example, so the returned count cannot be ignored: a short write is a
 // truncated event, not a delivered one.
 func writeFull(conn net.Conn, data []byte) error {

--- a/internal/connectionmanager/connection_test.go
+++ b/internal/connectionmanager/connection_test.go
@@ -133,6 +133,34 @@ func TestConnectionSendEventUnknownResponse(t *testing.T) {
 }
 
 // TestBatchingSingleEvent tests that a single event is sent immediately.
+// TestConnectionSendEventIgnoresStaleCallback verifies that a response left
+// behind by an event we already gave up on is not mistaken for the answer to
+// the current one.
+func TestConnectionSendEventIgnoresStaleCallback(t *testing.T) {
+	conn := NewConnection(uuid.NewString(), &MockConnection{}, 1024, 200*time.Millisecond)
+	go conn.EventProcessor()
+	defer conn.Close()
+
+	// A response nobody is waiting for anymore.
+	conn.Callback <- uuid.NewString() + " OK"
+
+	if err := conn.SendEvent("test_data"); err != nil {
+		t.Fatalf("Error should not be returned for successful event: %s", err)
+	}
+}
+
+// TestConnectionSendEventCallbackTimeout covers the deadline that applies when
+// nothing ever answers the event.
+func TestConnectionSendEventCallbackTimeout(t *testing.T) {
+	// No event processor is running, so the event is never answered.
+	conn := loadConnection(t)
+
+	err := conn.SendEvent("test_data")
+	if err == nil || err.Error() != "Timeout waiting for callback" {
+		t.Fatalf("Timeout error should be returned when nothing answers: %s", err)
+	}
+}
+
 func TestBatchingSingleEvent(t *testing.T) {
 	conn := loadConnection(t)
 	go conn.EventProcessor()

--- a/internal/connectionmanager/http_manager.go
+++ b/internal/connectionmanager/http_manager.go
@@ -203,8 +203,17 @@ func (h *HTTPManager) Delete(id string) {
 
 // Broadcast sends data to all registered SSE subscriber connections.
 func (h *HTTPManager) Broadcast(data string) (string, error) {
-	callback := make(chan string, 100)
-	defer close(callback)
+	h.lock.RLock()
+	connections := make([]Connection, 0, len(h.connections))
+	for _, conn := range h.connections {
+		connections = append(connections, conn)
+	}
+	h.lock.RUnlock()
+
+	// The callback channel has room for every response and is never closed:
+	// the event processors may answer late, after this deadline is over, and
+	// they must never block or send on a closed channel.
+	callback := make(chan string, len(connections))
 	dataBytes := []byte(data)
 
 	eventID := uuid.NewString()
@@ -215,38 +224,37 @@ func (h *HTTPManager) Broadcast(data string) (string, error) {
 		timeout:  time.Now().Add(200 * time.Millisecond),
 	}
 
-	h.lock.RLock()
-	connections := make([]Connection, 0, len(h.connections))
-	for _, conn := range h.connections {
-		connections = append(connections, conn)
-	}
-	h.lock.RUnlock()
-
 	sent := 0
 	received := 0
 	errors := 0
 
 	for _, conn := range connections {
-		select {
-		case conn.Events <- event:
-			sent++
-		default:
-			sent++
+		sent++
+		if !conn.Enqueue(event) {
 			errors++
 		}
 	}
 
-	timeout := time.Now().Add(200 * time.Millisecond)
+	// A single timer for the whole wait: time.After inside the loop would
+	// allocate one throwaway timer per response, and keep every one of them
+	// alive until the deadline passes.
+	timer := time.NewTimer(200 * time.Millisecond)
+	defer timer.Stop()
+	okResponse := eventID + " OK"
+
 outerLoop:
 	for received+errors < sent {
 		select {
 		case response := <-callback:
-			if response == eventID+" OK" {
+			if response == okResponse {
 				received++
 			} else {
 				errors++
 			}
-		case <-time.After(time.Until(timeout)):
+		case <-timer.C:
+			// Deliveries we never got confirmation for are failures, not
+			// silent successes.
+			errors = sent - received
 			break outerLoop
 		}
 	}
@@ -269,16 +277,7 @@ func (h *HTTPManager) Multicast(data string, targets []net.Conn, timeout time.Du
 
 // createConnection builds a Connection wrapping the provided net.Conn.
 func (h *HTTPManager) createConnection(nc net.Conn) Connection {
-	return Connection{
-		ID:          uuid.New().String(),
-		Quit:        make(chan interface{}),
-		Events:      make(chan Event, 128),
-		NetworkConn: nc,
-		LoggedUser:  auth.User{},
-		Callback:    make(chan string),
-		Buffer:      make([]byte, 41),
-		Timeout:     200 * time.Millisecond,
-	}
+	return NewConnection(uuid.New().String(), nc, 41, 200*time.Millisecond)
 }
 
 // addSSEConnection registers an SSE connection in the broadcast map.

--- a/internal/connectionmanager/multicast.go
+++ b/internal/connectionmanager/multicast.go
@@ -57,10 +57,9 @@ func multicastToConnections(connections []Connection, targets []net.Conn, data s
 		}
 
 		result.Sent++
-		select {
-		case conn.Events <- event:
+		if conn.Enqueue(event) {
 			events[eventID] = conn.NetworkConn
-		default:
+		} else {
 			result.Errors++
 			result.Failed = append(result.Failed, conn.NetworkConn)
 		}
@@ -73,6 +72,12 @@ func multicastToConnections(connections []Connection, targets []net.Conn, data s
 		result.Errors++
 		result.Failed = append(result.Failed, target)
 	}
+
+	// A single timer for the whole wait: time.After inside the loop would
+	// allocate one throwaway timer per response, and keep every one of them
+	// alive until the deadline passes.
+	timer := time.NewTimer(time.Until(deadline))
+	defer timer.Stop()
 
 	for len(events) > 0 {
 		select {
@@ -94,7 +99,7 @@ func multicastToConnections(connections []Connection, targets []net.Conn, data s
 				result.Errors++
 				result.Failed = append(result.Failed, conn)
 			}
-		case <-time.After(time.Until(deadline)):
+		case <-timer.C:
 			for _, conn := range events {
 				result.Errors++
 				result.Failed = append(result.Failed, conn)

--- a/internal/connectionmanager/stress_test.go
+++ b/internal/connectionmanager/stress_test.go
@@ -1,0 +1,287 @@
+package connectionmanager
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// slowConn is a net.Conn whose writes take longer than the broadcast deadline,
+// so the event processor answers the callback after the broadcaster gave up.
+type slowConn struct {
+	*TestConn
+	delay time.Duration
+}
+
+func (c *slowConn) Write(b []byte) (int, error) {
+	time.Sleep(c.delay)
+	return len(b), nil
+}
+
+// chunkedConn writes at most chunk bytes per call and reports the partial
+// count, the way net.Conn is allowed to.
+type chunkedConn struct {
+	*TestConn
+	chunk int
+
+	mu      sync.Mutex
+	written []byte
+}
+
+func (c *chunkedConn) Write(b []byte) (int, error) {
+	n := c.chunk
+	if n > len(b) {
+		n = len(b)
+	}
+
+	c.mu.Lock()
+	c.written = append(c.written, b[:n]...)
+	c.mu.Unlock()
+	return n, nil
+}
+
+func (c *chunkedConn) Written() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return string(c.written)
+}
+
+// stalledConn accepts nothing and reports no error, the short write that must
+// not be mistaken for a delivery.
+type stalledConn struct {
+	*TestConn
+}
+
+func (c *stalledConn) Write(b []byte) (int, error) {
+	return 0, nil
+}
+
+// TestConcurrentConnectDisconnectBroadcast hammers the manager with clients
+// connecting and disconnecting while broadcasts are in flight. Run under -race
+// it covers the connection map iteration and the event queue lifecycle.
+//
+// The number of connections is bounded on purpose: an unbounded churn loop
+// exhausts the ephemeral ports of the machine running the suite.
+func TestConcurrentConnectDisconnectBroadcast(t *testing.T) {
+	const clients = 8
+	const rounds = 15
+
+	manager := NewTCPManager()
+	if err := manager.StartListening("127.0.0.1:0"); err != nil {
+		t.Fatalf("Error starting the listener: %s", err)
+	}
+
+	addr := manager.GetAddr()
+	go manager.ServeConnections(func(_ int, _ []byte, conn *Connection) error { //nolint:errcheck
+		conn.SendEvent("v000ok\n") //nolint:errcheck
+		return nil
+	})
+
+	var churn sync.WaitGroup
+	for i := 0; i < clients; i++ {
+		churn.Add(1)
+		go func() {
+			defer churn.Done()
+			for round := 0; round < rounds; round++ {
+				client, err := net.Dial("tcp", addr)
+				if err != nil {
+					t.Errorf("Error connecting to the server: %s", err)
+					return
+				}
+
+				client.Write([]byte("r000\n")) //nolint:errcheck
+				buf := make([]byte, 64)
+				client.SetReadDeadline(time.Now().Add(200 * time.Millisecond)) //nolint:errcheck
+				client.Read(buf)                                               //nolint:errcheck
+				client.Close()
+			}
+		}()
+	}
+
+	done := make(chan struct{})
+	var broadcasters sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		broadcasters.Add(1)
+		go func() {
+			defer broadcasters.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+
+				if _, err := manager.Broadcast("a000hello\n"); err != nil {
+					t.Errorf("Error broadcasting message: %s", err)
+					return
+				}
+			}
+		}()
+	}
+
+	churn.Wait()
+	close(done)
+	broadcasters.Wait()
+	manager.Close()
+}
+
+// TestBroadcastLateCallbackDoesNotPanic covers the event processor answering
+// after the broadcast deadline expired: the callback channel outlives the
+// broadcast, so the late response is dropped instead of crashing the process.
+func TestBroadcastLateCallbackDoesNotPanic(t *testing.T) {
+	conn := NewConnection("slow", &slowConn{TestConn: &TestConn{}, delay: 400 * time.Millisecond}, 1024, 200*time.Millisecond)
+	go conn.EventProcessor()
+	defer conn.Close()
+
+	manager := TCPManager{
+		connections: map[string]Connection{conn.ID: conn},
+		quit:        make(chan interface{}),
+	}
+
+	output, err := manager.Broadcast("Hello World")
+	if err != nil {
+		t.Fatalf("Error broadcasting message: %s", err)
+	}
+
+	// The connection never confirmed in time, so it is not a delivery.
+	if output != "0/1/1" {
+		t.Fatalf("Expected '0/1/1', got %s", output)
+	}
+
+	// Give the processor time to answer into the channel the broadcast left
+	// behind. A closed channel would panic here.
+	time.Sleep(500 * time.Millisecond)
+}
+
+// TestHTTPBroadcastLateCallbackDoesNotPanic is the HTTP counterpart: the SSE
+// subscriber confirms after the deadline, so the broadcast reports it as a
+// failed delivery and the late response lands on a channel that is still open.
+func TestHTTPBroadcastLateCallbackDoesNotPanic(t *testing.T) {
+	conn := NewConnection("slow", &slowConn{TestConn: &TestConn{}, delay: 400 * time.Millisecond}, 1024, 200*time.Millisecond)
+	go conn.EventProcessor()
+	defer conn.Close()
+
+	manager := NewHTTPManager()
+	manager.connections[conn.ID] = conn
+
+	output, err := manager.Broadcast("Hello World")
+	if err != nil {
+		t.Fatalf("Error broadcasting message: %s", err)
+	}
+
+	if output != "0/1/1" {
+		t.Fatalf("Expected '0/1/1', got %s", output)
+	}
+
+	// Give the processor time to answer into the channel the broadcast left
+	// behind. A closed channel would panic here.
+	time.Sleep(500 * time.Millisecond)
+}
+
+// TestBroadcastToClosedConnection covers a connection that is closed while a
+// broadcaster still holds a copy of it: the delivery fails, it does not panic
+// sending on a closed queue.
+func TestBroadcastToClosedConnection(t *testing.T) {
+	conn := NewConnection("closed", &TestConn{}, 1024, 200*time.Millisecond)
+	go conn.EventProcessor()
+	conn.Close()
+
+	manager := TCPManager{
+		connections: map[string]Connection{conn.ID: conn},
+		quit:        make(chan interface{}),
+	}
+
+	output, err := manager.Broadcast("Hello World")
+	if err != nil {
+		t.Fatalf("Error broadcasting message: %s", err)
+	}
+
+	if output != "0/1/1" {
+		t.Fatalf("Expected '0/1/1', got %s", output)
+	}
+}
+
+// TestPartialWriteIsCompleted verifies that a connection that only accepts a
+// few bytes per call still receives the whole event.
+func TestPartialWriteIsCompleted(t *testing.T) {
+	network := &chunkedConn{TestConn: &TestConn{}, chunk: 3}
+	conn := NewConnection("chunked", network, 1024, 200*time.Millisecond)
+	go conn.EventProcessor()
+	defer conn.Close()
+
+	callback := make(chan string, 1)
+	conn.Enqueue(Event{
+		id:       "event",
+		data:     []byte("Hello World"),
+		callback: callback,
+		timeout:  time.Now().Add(time.Second),
+	})
+
+	select {
+	case response := <-callback:
+		if response != "event OK" {
+			t.Fatalf("Expected 'event OK', got %s", response)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Timeout waiting for the event response")
+	}
+
+	if network.Written() != "Hello World" {
+		t.Fatalf("Expected the full message to be written, got %q", network.Written())
+	}
+}
+
+// TestShortWriteIsReportedAsError verifies that a write that makes no progress
+// is not acknowledged as a delivery.
+func TestShortWriteIsReportedAsError(t *testing.T) {
+	conn := NewConnection("stalled", &stalledConn{TestConn: &TestConn{}}, 1024, 200*time.Millisecond)
+	go conn.EventProcessor()
+	defer conn.Close()
+
+	callback := make(chan string, 1)
+	conn.Enqueue(Event{
+		id:       "event",
+		data:     []byte("Hello World"),
+		callback: callback,
+		timeout:  time.Now().Add(time.Second),
+	})
+
+	select {
+	case response := <-callback:
+		if response != "event ERROR" {
+			t.Fatalf("Expected 'event ERROR', got %s", response)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Timeout waiting for the event response")
+	}
+}
+
+// TestClosingConnectionFailsQueuedEvents verifies that the events still queued
+// when a connection goes away are answered instead of being left hanging until
+// their deadline.
+func TestClosingConnectionFailsQueuedEvents(t *testing.T) {
+	conn := NewConnection("draining", &slowConn{TestConn: &TestConn{}, delay: 100 * time.Millisecond}, 1024, 200*time.Millisecond)
+	go conn.EventProcessor()
+
+	callback := make(chan string, 4)
+	for i := 0; i < 4; i++ {
+		conn.Enqueue(Event{
+			id:       "event",
+			data:     []byte("Hello World"),
+			callback: callback,
+			timeout:  time.Now().Add(5 * time.Second),
+		})
+	}
+
+	conn.Close()
+
+	deadline := time.After(2 * time.Second)
+	for i := 0; i < 4; i++ {
+		select {
+		case <-callback:
+		case <-deadline:
+			t.Fatalf("Only %d of the 4 queued events were answered", i)
+		}
+	}
+}

--- a/internal/connectionmanager/tcp_broadcast_test.go
+++ b/internal/connectionmanager/tcp_broadcast_test.go
@@ -18,7 +18,7 @@ func (c *TestConn) Read(b []byte) (n int, err error) {
 }
 
 func (c *TestConn) Write(b []byte) (n int, err error) {
-	return 0, nil
+	return len(b), nil
 }
 
 func (c *TestConn) Close() error {

--- a/internal/connectionmanager/tcp_manager.go
+++ b/internal/connectionmanager/tcp_manager.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/dankomiocevic/ghoti/internal/auth"
 	"github.com/dankomiocevic/ghoti/internal/errs"
 	"github.com/dankomiocevic/ghoti/internal/telemetry"
 )
@@ -158,19 +157,7 @@ func (c *TCPManager) Add(conn net.Conn, bufferSize int) Connection {
 	//TODO: Add this to config
 	timeoutDuration := 200 * time.Millisecond
 
-	buf := make([]byte, bufferSize)
-	connection := Connection{
-		ID:          id,
-		Quit:        make(chan interface{}),
-		Events:      make(chan Event, 128),
-		NetworkConn: conn,
-		LoggedUser:  auth.User{},
-		Username:    "",
-		IsLogged:    false,
-		Callback:    make(chan string),
-		Buffer:      buf,
-		Timeout:     timeoutDuration,
-	}
+	connection := NewConnection(id, conn, bufferSize, timeoutDuration)
 
 	c.connections[connection.ID] = connection
 	telemetry.IncrConnectedClients()
@@ -232,8 +219,20 @@ func (c *TCPManager) Multicast(data string, targets []net.Conn, timeout time.Dur
 }
 
 func (c *TCPManager) Broadcast(data string) (string, error) {
-	callback := make(chan string, 100)
-	defer close(callback)
+	// Take a snapshot of the connections under the lock: iterating the map
+	// directly races with the connections being added and removed as clients
+	// come and go.
+	c.lock.RLock()
+	connections := make([]Connection, 0, len(c.connections))
+	for _, conn := range c.connections {
+		connections = append(connections, conn)
+	}
+	c.lock.RUnlock()
+
+	// The callback channel has room for every response and is never closed:
+	// the event processors may answer late, after this deadline is over, and
+	// they must never block or send on a closed channel.
+	callback := make(chan string, len(connections))
 	dataBytes := []byte(data)
 
 	eventID := uuid.NewString()
@@ -248,47 +247,34 @@ func (c *TCPManager) Broadcast(data string) (string, error) {
 	received := 0
 	errors := 0
 
-	// Fix the concurrency issue here with range when removing connections on
-	// another goroutine
-	for _, conn := range c.connections {
-		select {
-		case conn.Events <- event:
-			sent++
-		default:
-			sent++
+	for _, conn := range connections {
+		sent++
+		if !conn.Enqueue(event) {
 			errors++
-		}
-
-		if sent-received-errors > 90 {
-			for sent-received-errors > 50 {
-				// Start consuming messages from the callback channel that might be ready
-				select {
-				case response := <-callback:
-					if response == eventID+" OK" {
-						received++
-					} else {
-						errors++
-					}
-				default:
-				}
-			}
 		}
 	}
 
-	// Get the time 200 ms in the future
-	timeout := time.Now().Add(200 * time.Millisecond)
+	// A single timer for the whole wait: time.After inside the loop would
+	// allocate one throwaway timer per response, and keep every one of them
+	// alive until the deadline passes.
+	timer := time.NewTimer(200 * time.Millisecond)
+	defer timer.Stop()
+	okResponse := eventID + " OK"
 
 	// Wait for all the missing responses
 outerLoop:
 	for received+errors < sent {
 		select {
 		case response := <-callback:
-			if response == eventID+" OK" {
+			if response == okResponse {
 				received++
 			} else {
 				errors++
 			}
-		case <-time.After(time.Until(timeout)):
+		case <-timer.C:
+			// Deliveries we never got confirmation for are failures, not
+			// silent successes.
+			errors = sent - received
 			break outerLoop
 		}
 	}


### PR DESCRIPTION
Fix broadcast races by making the event processor the only owner of each connection's queue