### PR TITLE
Remove plaintext logging for passwords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,22 @@ go.work
 
 # Buids
 dist/
+
+# Credentials and keys. A secret that reaches the history has to be treated
+# as compromised and rotated, removing it from the history is not enough.
+*.pem
+*.key
+*.p12
+*.pfx
+*_rsa
+*_ed25519
+
+# Local configuration, it usually carries user and cluster passwords.
+# config.yaml is tracked as an example, keep real credentials out of it and
+# put them in the environment or in a config file outside the repository.
+config.tmp
+config_full.yaml
+config_local.*
+config.local.*
+.env
+.env.*

--- a/README.md
+++ b/README.md
@@ -456,7 +456,15 @@ send   > pmy_password
 receive< vmy_service
 ```
 
-The server will respond with the `v` value returning the username of the logged in user or `e` if there is an error. It is recommended using this feature only through a secure connection, on a very secure network or through TTL because the passwords will not be encoded.
+The server will respond with the `v` value returning the username of the logged in user or `e` if there is an error.
+
+> **The password travels as cleartext.** Ghoti does not implement TLS on any
+> of its listeners, so the `p` command sends the password in the clear and
+> anybody observing the traffic can read it. Terminate TLS in a reverse proxy
+> in front of the server, or keep the traffic on loopback or an equivalent
+> trusted transport. See [SECURITY.md](SECURITY.md) for the full security
+> model and for how to inject credentials from the environment instead of
+> committing them to a configuration file.
 
 Now, all the interactions with the server will be throught the autenticated user.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,139 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities **privately**. Do not open a public
+issue, and do not disclose the problem in a pull request, a discussion or any
+other public channel before a fix is available.
+
+Use GitHub's private vulnerability reporting to open a report:
+
+<https://github.com/dankomiocevic/ghoti/security/advisories/new>
+
+Include as much of the following as you can:
+
+- The version, commit or tag affected.
+- The configuration needed to reproduce it, with any credential replaced.
+- A description of the impact and, if you have one, a proof of concept.
+- Whether the issue is already public anywhere.
+
+You should get an acknowledgement within 7 days. Once the report is
+confirmed, a fix and an advisory are prepared together and you are credited
+in the advisory unless you prefer to stay anonymous.
+
+Please do not include real credentials, production log excerpts or packet
+captures that carry secrets in a report. Redact them first.
+
+## Supported Versions
+
+Security fixes are applied to the latest released version. There is no
+backport of fixes to older releases.
+
+## Security Model
+
+Ghoti is designed to run **inside a trusted network boundary**. Understanding
+what it does and does not protect is necessary to deploy it safely.
+
+### There is no transport encryption
+
+None of the listeners implement TLS:
+
+| Listener | Protocol | Encryption |
+|---|---|---|
+| Server (`addr`) | Ghoti TCP / Telnet | none |
+| Server (`addr`, `protocol: http`) | HTTP and SSE | none |
+| Cluster manager (`cluster.manager.addr`) | HTTP with Basic auth | none |
+| Cluster bind (`cluster.bind`) | inter node traffic | none |
+
+This has direct consequences:
+
+- The `p` command sends the password as **cleartext bytes** on the wire.
+- Cluster traffic authenticates with **HTTP Basic**, which is only a Base64
+  encoding of the shared credentials and offers no confidentiality
+  ([RFC 7617](https://datatracker.ietf.org/doc/html/rfc7617)). It is not
+  secure without TLS.
+
+Anybody able to observe the traffic can recover every credential. This
+includes passive capture on the network path, a load balancer terminating
+connections in front of Ghoti, and any hop between nodes of a cluster.
+
+### Deploying safely
+
+**TLS is a mandatory part of any deployment that is not entirely local.**
+Ghoti does not provide it, so it has to be provided around it:
+
+- Terminate TLS in a reverse proxy or a service mesh sidecar in front of
+  every listener, and make sure the plaintext hop between the proxy and
+  Ghoti stays on loopback.
+- For inter node cluster traffic, use mutual TLS between the nodes, a VPN,
+  or an equivalent encrypted transport. The cluster credentials are a shared
+  secret for the whole cluster, so a single observed request compromises
+  every node.
+- Never expose a plaintext listener to an untrusted network.
+
+### Listeners bind to loopback by default
+
+The defaults are deliberately closed:
+
+| Setting | Default |
+|---|---|
+| `addr` | `localhost:9090` |
+| `cluster.bind` | `localhost:25873` |
+
+Changing these to a routable address exposes an unencrypted service. Only do
+it behind one of the encrypted transports described above, and prefer binding
+to a specific private interface over `0.0.0.0`.
+
+### The `/leader` endpoint is unauthenticated
+
+`cluster.leader.enabled` serves `GET /leader` without authentication, because
+load balancer health checks cannot send credentials. It discloses whether the
+node is the leader and the current leader's node ID. It is opt-in and should
+only be reachable from the load balancer.
+
+## Credentials and Logging
+
+Credential values are never written to the logs. Specifically:
+
+- The message parser redacts the value of the `u` and `p` commands before
+  logging the received message, so a password is never logged even at the
+  `debug` level.
+- A failed cluster authentication logs the remote address only. It never logs
+  the supplied credentials, and never the configured ones.
+
+These properties are covered by tests in `internal/server/redaction_test.go`
+and `internal/cluster/redaction_test.go`. Any change that logs a credential
+value should fail them. When adding a log line that touches authentication,
+log the identifier and the remote address, never the secret.
+
+## Keeping Credentials Out of the Repository
+
+Ghoti reads its configuration with [Viper](https://github.com/spf13/viper).
+Every configuration key can also be supplied as an environment variable
+prefixed with `GHOTI_`, with dots and dashes replaced by underscores, so a
+credential does not have to be written into a YAML file that risks being
+committed:
+
+```sh
+export GHOTI_CLUSTER_USER=cluster_node
+export GHOTI_CLUSTER_PASS="$(cat /run/secrets/ghoti_cluster_pass)"
+```
+
+The surrounding structure still has to exist in the configuration file, the
+environment supplies the value. One exception: the `users` block is read as a
+map, and map entries cannot be injected from the environment, so per user
+passwords still have to come from the configuration file. Keep that file
+outside the repository.
+
+Prefer, in this order:
+
+1. A secret manager that injects the value into the environment or into a
+   file mounted at runtime.
+2. Environment variables, as shown above.
+3. A configuration file **outside** the repository, owned by the service user
+   and with `0600` permissions.
+
+If you must use a configuration file, make sure it is listed in
+`.gitignore` and never committed. A credential that reached a git history has
+to be treated as compromised and rotated, removing it from the history is not
+enough.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,12 +9,17 @@ import (
 )
 
 // NewRootCommand enables all children commands to read flags from CLI flags, environment variables prefixed with GHOTI, or config.yaml (in that order).
+//
+// The key replacer maps both dashes and dots to underscores so that nested
+// configuration keys can be set from the environment: cluster.pass is read
+// from GHOTI_CLUSTER_PASS. This is what allows a credential to be injected at
+// runtime instead of being written into a configuration file.
 func NewRootCommand() *cobra.Command {
 	viper.SetConfigName("config")
 	viper.SetConfigType("yaml")
 
 	viper.SetEnvPrefix("GHOTI")
-	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
 	viper.AutomaticEnv()
 
 	configPaths := []string{"/etc/ghoti", "$HOME/.ghoti", "."}

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -35,7 +35,7 @@ func TestClusterFail(t *testing.T) {
 	viper.SetConfigType("yaml")
 
 	viper.SetEnvPrefix("GHOTI")
-	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
 	viper.AutomaticEnv()
 
 	configPaths := []string{"/etc/ghoti", "$HOME/.ghoti", ".", "../.."}

--- a/internal/cluster/join_server.go
+++ b/internal/cluster/join_server.go
@@ -101,11 +101,12 @@ func (s *joinServer) handleJoin(w http.ResponseWriter, r *http.Request) {
 	user, pass, _ := r.BasicAuth()
 
 	if user != s.user || pass != s.pass {
+		// Never log the supplied or the configured credentials here: this
+		// line can be triggered by anybody able to reach the endpoint, so
+		// logging them would hand the shared cluster secret to every reader
+		// of the logs. The remote address is enough to chase the caller.
 		slog.Warn("Request to join with wrong username/password",
-			"user", user,
-			"pass", pass,
-			"s_user", s.user,
-			"s_pass", s.pass,
+			slog.String("remote_addr", r.RemoteAddr),
 		)
 		w.WriteHeader(http.StatusBadRequest)
 		return
@@ -204,7 +205,9 @@ func (s *joinServer) handleRemove(w http.ResponseWriter, r *http.Request) {
 
 	user, pass, _ := r.BasicAuth()
 	if user != s.user || pass != s.pass {
-		slog.Warn("Request to remove with wrong username/password")
+		slog.Warn("Request to remove with wrong username/password",
+			slog.String("remote_addr", r.RemoteAddr),
+		)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,7 @@ import (
 
 var SupportedLogLevels = map[string]slog.Level{
 	"debug": slog.LevelDebug,
-	"info":  slog.LevelDebug,
+	"info":  slog.LevelInfo,
 	"warn":  slog.LevelWarn,
 	"error": slog.LevelError,
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -33,7 +33,7 @@ func resetViper(t *testing.T, data string) {
 	viper.SetConfigType("yaml")
 
 	viper.SetEnvPrefix("GHOTI")
-	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
 	viper.AutomaticEnv()
 
 	viper.AddConfigPath("/etc/ghoti")

--- a/internal/server/message.go
+++ b/internal/server/message.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 )
 
@@ -56,6 +57,24 @@ func parseSlot(digits string) (int, error) {
 	return slot, nil
 }
 
+// credentialCommands are the commands that carry a credential as their
+// value. Their argument must never reach the logs.
+var credentialCommands = map[byte]bool{
+	'u': true,
+	'p': true,
+}
+
+// redactCredentials returns a representation of the message that is safe to
+// log. Commands carrying a credential keep the command byte and the length of
+// the value, so a malformed message can still be diagnosed, but the value
+// itself is replaced. Every other command is returned untouched.
+func redactCredentials(command byte, input string) string {
+	if !credentialCommands[command] {
+		return input
+	}
+	return fmt.Sprintf("%c<redacted:%d bytes>", command, len(input)-1)
+}
+
 func ParseMessage(size int, buf []byte) (Message, error) {
 	if size < 0 || size > len(buf) {
 		return Message{}, errors.New("invalid message size")
@@ -67,7 +86,7 @@ func ParseMessage(size int, buf []byte) (Message, error) {
 	}
 
 	command := input[0]
-	slog.Debug("Message received", slog.String("input", input))
+	slog.Debug("Message received", slog.String("input", redactCredentials(command, input)))
 
 	if command == 'q' {
 		if len(input) > 1 {


### PR DESCRIPTION
Some logs were exposing the passwords sent from the clients, this PR fixes that. Also, adding some clarifications regarding TLS and unencrypted communications.