### PR TITLE
Fix loop when joining cluster

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -11,7 +11,7 @@ import (
 
 type Cluster interface {
 	Start() error
-	Join(string, string) error
+	Join(string, string) (bool, error)
 	Remove(string) error
 	IsLeader() bool
 	GetLeader() string
@@ -90,9 +90,23 @@ func (c *BullyCluster) GetLeader() string {
 	return c.leader
 }
 
-func (c *BullyCluster) Join(nodeID, addr string) error {
+// Join adds a peer to the cluster membership.
+//
+// It reports whether the membership actually changed, which is what stops
+// join notifications from circulating forever: peers forward a join to each
+// other, so a node that has already recorded the peer must stay quiet instead
+// of reflecting the notification back to the sender.
+func (c *BullyCluster) Join(nodeID, addr string) (bool, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	if current, ok := c.peers[nodeID]; ok && current == addr {
+		slog.Debug("Peer already known, ignoring join",
+			slog.String("node_id", nodeID),
+			slog.String("addr", addr),
+		)
+		return false, nil
+	}
 
 	slog.Info("Adding peer to cluster",
 		slog.String("node_id", nodeID),
@@ -100,7 +114,7 @@ func (c *BullyCluster) Join(nodeID, addr string) error {
 	)
 
 	c.peers[nodeID] = addr
-	return nil
+	return true, nil
 }
 
 func (c *BullyCluster) Remove(nodeID string) error {

--- a/internal/cluster/empty_cluster.go
+++ b/internal/cluster/empty_cluster.go
@@ -11,8 +11,8 @@ func (c *EmptyCluster) Start() error {
 	return nil
 }
 
-func (c *EmptyCluster) Join(a, b string) error {
-	return nil
+func (c *EmptyCluster) Join(a, b string) (bool, error) {
+	return false, nil
 }
 
 func (c *EmptyCluster) Remove(a string) error {

--- a/internal/cluster/empty_cluster_test.go
+++ b/internal/cluster/empty_cluster_test.go
@@ -12,9 +12,12 @@ func TestEmptyCluster(t *testing.T) {
 		t.Fatalf("Method Start should always return nil")
 	}
 
-	err = c.Join("", "")
+	changed, err := c.Join("", "")
 	if err != nil {
 		t.Fatalf("Method Join should always return nil")
+	}
+	if changed {
+		t.Fatalf("Method Join should never report a membership change")
 	}
 
 	err = c.Remove("")

--- a/internal/cluster/join_server.go
+++ b/internal/cluster/join_server.go
@@ -9,7 +9,14 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"sync/atomic"
+	"time"
 )
+
+// peerNotifyTimeout bounds every request this node makes to a peer join
+// endpoint. Without it a peer that accepts the connection and never answers
+// pins the calling goroutine forever.
+const peerNotifyTimeout = 5 * time.Second
 
 type joinServer struct {
 	addr    string
@@ -23,6 +30,13 @@ type joinServer struct {
 	ln            net.Listener
 	server        *http.Server
 	wg            sync.WaitGroup
+	joinRequests  atomic.Uint64
+}
+
+// JoinRequestCount returns the number of authenticated join requests this
+// node has served since it started.
+func (s *joinServer) JoinRequestCount() uint64 {
+	return s.joinRequests.Load()
 }
 
 func (s *joinServer) Start() error {
@@ -41,7 +55,9 @@ func (s *joinServer) Start() error {
 
 		for id, addr := range peers {
 			if id != s.nodeID {
-				s.cluster.Join(id, addr)
+				if _, err := s.cluster.Join(id, addr); err != nil {
+					return err
+				}
 			}
 		}
 		s.cluster.SetLeader(leader)
@@ -112,6 +128,8 @@ func (s *joinServer) handleJoin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.joinRequests.Add(1)
+
 	m := map[string]string{}
 	if err := json.NewDecoder(r.Body).Decode(&m); err != nil {
 		slog.Debug("JSON request cannot be decoded")
@@ -139,7 +157,7 @@ func (s *joinServer) handleJoin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := s.cluster.Join(nodeID, remoteAddr)
+	changed, err := s.cluster.Join(nodeID, remoteAddr)
 	if err != nil {
 		slog.Warn("Error joining cluster",
 			slog.Any("error", err),
@@ -160,13 +178,20 @@ func (s *joinServer) handleJoin(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)
 
+	if !changed {
+		slog.Debug("Join for an already known peer, not notifying other peers",
+			slog.String("node_id", nodeID),
+		)
+		return
+	}
+
 	// Notify existing peers about the new node
 	go s.notifyPeersOfNewNode(nodeID, remoteAddr)
 }
 
 func (s *joinServer) notifyPeersOfNewNode(newNodeID, newNodeAddr string) {
 	peers := s.cluster.GetPeers()
-	client := &http.Client{}
+	client := &http.Client{Timeout: peerNotifyTimeout}
 
 	for id, addr := range peers {
 		if id == newNodeID || id == s.nodeID {
@@ -339,7 +364,7 @@ func requestToJoin(joinAddr, managerAddr, nodeID, user, pass string) (map[string
 	req.Header.Add("Content-Type", "application/json")
 	req.SetBasicAuth(user, pass)
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: peerNotifyTimeout}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, "", err

--- a/internal/cluster/join_storm_test.go
+++ b/internal/cluster/join_storm_test.go
@@ -1,0 +1,96 @@
+package cluster
+
+import (
+	"testing"
+	"time"
+)
+
+// joinServerOf returns the join server backing a cluster node so a test can
+// inspect how many join requests that node has served.
+func joinServerOf(t *testing.T, c *BullyCluster) *joinServer {
+	t.Helper()
+	js, ok := c.manager.(*joinServer)
+	if !ok {
+		t.Fatalf("node %s is not backed by a join server", c.nodeID)
+	}
+	return js
+}
+
+// waitForPeers blocks until the node knows about the expected number of peers.
+func waitForPeers(t *testing.T, c *BullyCluster, want int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if len(c.GetPeers()) == want && c.GetLeader() != "" {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("node %s did not converge on %d peers within timeout, has %d",
+		c.nodeID, want, len(c.GetPeers()))
+}
+
+// TestJoinNotificationsStopAfterConvergence guards against a join notification
+// storm: once every node knows every other node, no further join traffic must
+// be generated. Peers that re-broadcast a join they already know about make
+// each other repeat the notification forever, which keeps every node in the
+// cluster busy serving join requests until it falls over.
+func TestJoinNotificationsStopAfterConvergence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test on Short mode")
+	}
+
+	configs := []ClusterConfig{
+		{Node: "node1", User: "my_user", Pass: "my_pass", ManagerType: "join_server", ManagerAddr: "localhost:2331", ManagerJoin: "", Bind: "localhost:1331"},
+		{Node: "node2", User: "my_user", Pass: "my_pass", ManagerType: "join_server", ManagerAddr: "localhost:2332", ManagerJoin: "localhost:2331", Bind: "localhost:1332"},
+		{Node: "node3", User: "my_user", Pass: "my_pass", ManagerType: "join_server", ManagerAddr: "localhost:2333", ManagerJoin: "localhost:2331", Bind: "localhost:1333"},
+	}
+
+	nodes := make([]*BullyCluster, 0, len(configs))
+	for _, config := range configs {
+		node, err := NewCluster(config)
+		if err != nil {
+			t.Fatalf("failed to create %s: %s", config.Node, err)
+		}
+		if err := node.Start(); err != nil {
+			t.Fatalf("failed to start %s: %s", config.Node, err)
+		}
+		defer node.Shutdown()
+		nodes = append(nodes, node)
+	}
+
+	// Every node must end up knowing the other two.
+	for _, node := range nodes {
+		waitForPeers(t, node, len(nodes)-1, 10*time.Second)
+	}
+
+	counts := func() []uint64 {
+		result := make([]uint64, len(nodes))
+		for i, node := range nodes {
+			result[i] = joinServerOf(t, node).JoinRequestCount()
+		}
+		return result
+	}
+
+	before := counts()
+	time.Sleep(2 * time.Second)
+	after := counts()
+
+	for i, node := range nodes {
+		if after[i] != before[i] {
+			t.Fatalf("node %s kept serving join requests after convergence: %d -> %d over 2s (join notifications are looping between peers)",
+				node.nodeID, before[i], after[i])
+		}
+	}
+
+	// A converged three node cluster should have needed very little join
+	// traffic in total: node1 serves the two direct joins, and each of the
+	// other two learns about the remaining node through a single notification.
+	total := uint64(0)
+	for _, c := range after {
+		total += c
+	}
+	if total > uint64(len(nodes)*len(nodes)) {
+		t.Fatalf("three node cluster served %d join requests to converge, expected at most %d", total, len(nodes)*len(nodes))
+	}
+}


### PR DESCRIPTION
There was no mechanism to stop notifications to join a cluster. So, once the cluster is created, a new node could trigger a storm of join requests that have no limit. This PR adds a flag to notify if the node is already registered.